### PR TITLE
[sc-13232] Update `fields__description` attribute

### DIFF
--- a/jira.sgnl.yaml
+++ b/jira.sgnl.yaml
@@ -254,8 +254,11 @@ entities:
       - name: fields__timeoriginalestimate
         externalId: fields__timeoriginalestimate
         type: String
-      - name: fields__description
-        externalId: fields__description
+      - name: fields__description__version
+        externalId: fields__description__version
+        type: Int64
+      - name: fields__description__type
+        externalId: fields__description__type
         type: String
       - name: fields__security
         externalId: fields__security


### PR DESCRIPTION
The `fields__description` attribute is not a string but an object:
```json
"description": {
  "version": 1,
  "type": "doc",
  "content": [
      {
          "type": "paragraph",
          "content": [
              {
                  "type": "text",
                  "text": "Demo incident."
              }
          ]
      }
  ]
},
```
Since we currently don't support multi valued complex attributes, e.g. `content`, we can only sync `description__version` and `description__type`. 