### PR TITLE
[sc-11899] Remove Adapter object from templates

### DIFF
--- a/azure-ad.sgnl.yaml
+++ b/azure-ad.sgnl.yaml
@@ -8,19 +8,16 @@ defaultSyncFrequency: HOURLY
 defaultSyncMinInterval: 1
 defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
-adapter:
-  hostname: "adapter.sgnl.svc.cluster.local"
-  port: 80
-  config: "ewoJInZlcnNpb24iOiAxLAoJImNvbmZpZyI6IHsKICAgICAgICAgICAgICAgICJmaWx0ZXJzIjoge30sCgkJInJlcXVlc3RUaW1lb3V0IjogIjEwcyIsCgkJImF6dXJlYWQiOiB7CiAgICAgICAgICAgICAgICAgICAgImFwaVZlcnNpb24iOiAidjEuMCIKICAgICAgICAgICAgICAgIH0KCX0KfQ=="
-  apiVersion: "V1"
-  disableTls: true
-  auth:
-    - oAuth2ClientCredentials:
-        clientId: "{{Input Required: Client-ID}}"
-        scope: "https://graph.microsoft.com/.default"
-        tokenUrl: "https://login.microsoftonline.com/{{Input Required: Tenant-ID}}/oauth2/v2.0/token"
-        authStyle: InParams
-        clientSecret: "{{Input Required: Client-Secret}}"
+type: "AzureAD-1.0.0"
+adapterConfig: "ewoJInZlcnNpb24iOiAxLAoJImNvbmZpZyI6IHsKICAgICAgICAgICAgICAgICJmaWx0ZXJzIjoge30sCgkJInJlcXVlc3RUaW1lb3V0IjogIjEwcyIsCgkJImF6dXJlYWQiOiB7CiAgICAgICAgICAgICAgICAgICAgImFwaVZlcnNpb24iOiAidjEuMCIKICAgICAgICAgICAgICAgIH0KCX0KfQ=="
+# This must match the list of supportedAuthMechanisms specified on the Adapter.
+auth:
+  - oAuth2ClientCredentials:
+      clientId: "{{Input Required: Client-ID}}"
+      scope: "https://graph.microsoft.com/.default"
+      tokenUrl: "https://login.microsoftonline.com/{{Input Required: Tenant-ID}}/oauth2/v2.0/token"
+      authStyle: InParams
+      clientSecret: "{{Input Required: Client-Secret}}"
 entities:
   # Configuring complex attributes will cap the page size in AAD's API response to 100.
   # See: https://learn.microsoft.com/en-us/graph/known-issues?view=graph-rest-1.0#some-limitations-apply-to-query-parameters

--- a/azure-ad.sgnl.yaml
+++ b/azure-ad.sgnl.yaml
@@ -9,6 +9,8 @@ defaultSyncMinInterval: 1
 defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
 type: "AzureAD-1.0.0"
+# Example Config:
+# {"version": 1, "config": {"filters": {}, "requestTimeout": "10s", "azuread": {"apiVersion": "v1.0"}}}
 adapterConfig: "ewoJInZlcnNpb24iOiAxLAoJImNvbmZpZyI6IHsKICAgICAgICAgICAgICAgICJmaWx0ZXJzIjoge30sCgkJInJlcXVlc3RUaW1lb3V0IjogIjEwcyIsCgkJImF6dXJlYWQiOiB7CiAgICAgICAgICAgICAgICAgICAgImFwaVZlcnNpb24iOiAidjEuMCIKICAgICAgICAgICAgICAgIH0KCX0KfQ=="
 # This must match the list of supportedAuthMechanisms specified on the Adapter.
 auth:

--- a/custom.sgnl.yaml
+++ b/custom.sgnl.yaml
@@ -6,20 +6,17 @@ defaultSyncFrequency: HOURLY
 defaultSyncMinInterval: 1
 defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
-adapter:
-  hostname: "{{Input Required: Hostname}}"
-  port: 80
-  config: "{{Input Required: Config}}"
-  apiVersion: "V1"
-  disableTls: true
-  auth:
-    - oAuth2ClientCredentials:
-        clientId: "{{Input Required: Client-ID}}"
-        tokenUrl: "{{Input Required: Token-URL}}"
-        authStyle: "AutoDetect"
-        clientSecret: "{{Input Required: Client-Secret}}"
-    - basic:
-        username: "{{Input Required: Username}}"
-        password: "{{Input Required: Password}}"
-    - bearer:
-        authToken: "{{Input Required: AuthToken}}"
+type: "{{Input Required: SoR-Type}}"
+adapterConfig: "{{Input Required: Adapter-Config}}"
+# This must match the list of supportedAuthMechanisms specified on the Adapter.
+auth:
+  - oAuth2ClientCredentials:
+      clientId: "{{Input Required: Client-ID}}"
+      tokenUrl: "{{Input Required: Token-URL}}"
+      authStyle: "AutoDetect"
+      clientSecret: "{{Input Required: Client-Secret}}"
+  - basic:
+      username: "{{Input Required: Username}}"
+      password: "{{Input Required: Password}}"
+  - bearer:
+      authToken: "{{Input Required: AuthToken}}"

--- a/jira.sgnl.yaml
+++ b/jira.sgnl.yaml
@@ -7,21 +7,17 @@ defaultSyncFrequency: HOURLY
 defaultSyncMinInterval: 1
 defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
-adapter:
-  hostname: "adapter-sgnl.sgnl.svc.cluster.local"
-  port: 80
-  # Example Configs:
-  # empty config: {} | b64: "e30="
-  # config with issues jql filter: {"issuesJqlFilter":"project=SGNL"} | b64: "eyJpc3N1ZXNKcWxGaWx0ZXIiOiJwcm9qZWN0PVNHTkwifQ=="
-  # config with issues jql filter with space {"issuesJqlFilter":"project='Customer Support'"} | b64: "eyJpc3N1ZXNKcWxGaWx0ZXIiOiJwcm9qZWN0PSdDdXN0b21lciBTdXBwb3J0JyJ9"
-  config: "e30="
-  apiVersion: "V1"
-  disableTls: true
-  auth:
-    - basic:
-        username: "{{Input Required: Username}}"
-        password: "{{Input Required: API Token}}"
-
+type: "Jira-1.0.0"
+# Example Configs:
+# empty config: {} | b64: "e30="
+# config with issues jql filter: {"issuesJqlFilter":"project=SGNL"} | b64: "eyJpc3N1ZXNKcWxGaWx0ZXIiOiJwcm9qZWN0PVNHTkwifQ=="
+# config with issues jql filter with space {"issuesJqlFilter":"project='Customer Support'"} | b64: "eyJpc3N1ZXNKcWxGaWx0ZXIiOiJwcm9qZWN0PSdDdXN0b21lciBTdXBwb3J0JyJ9"
+adapterConfig: "e30="
+# This must match the list of supportedAuthMechanisms specified on the Adapter.
+auth:
+  - basic:
+      username: "{{Input Required: Username}}"
+      password: "{{Input Required: API Token}}"
 entities:
   User:
     # https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-user-search/#api-rest-api-3-user-search-get

--- a/okta.sgnl.yaml
+++ b/okta.sgnl.yaml
@@ -9,6 +9,8 @@ defaultSyncMinInterval: 1
 defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
 type: "Okta-1.0.0"
+# Example Config:
+# {"version": 1, "config": {"requestTimeout": "10s", "okta": {"apiVersion": "v1"}}}
 adapterConfig: "ewogICAgInZlcnNpb24iOiAxLAogICAgImNvbmZpZyI6IHsKICAgICAgICAicmVxdWVzdFRpbWVvdXQiOiAiMTBzIiwKICAgICAgICAib2t0YSI6IHsKICAgICAgICAgICAgImFwaVZlcnNpb24iOiAidjEiCiAgICAgICAgfQogICAgfQp9"
 # This must match the list of supportedAuthMechanisms specified on the Adapter.
 auth:

--- a/okta.sgnl.yaml
+++ b/okta.sgnl.yaml
@@ -8,22 +8,18 @@ defaultSyncFrequency: HOURLY
 defaultSyncMinInterval: 1
 defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
-adapter:
-  hostname: "adapter.sgnl.svc.cluster.local"
-  port: 80
-  config: "ewogICAgInZlcnNpb24iOiAxLAogICAgImNvbmZpZyI6IHsKICAgICAgICAicmVxdWVzdFRpbWVvdXQiOiAiMTBzIiwKICAgICAgICAib2t0YSI6IHsKICAgICAgICAgICAgImFwaVZlcnNpb24iOiAidjEiCiAgICAgICAgfQogICAgfQp9"
-  apiVersion: "V1"
-  disableTls: true
-  auth:
-    - oAuth2ClientCredentials:
-        clientId: "{{Input Required: Client-ID}}"
-        tokenUrl: "https://{{Input Required: Okta-Domain}}/oauth2/v1/token"
-        authStyle: AutoDetect
-        clientSecret: "{{Input Required: Client-Secret}}"
-        scope: "okta.users.read okta.groups.read"
-    - bearer:
-        authToken: "{{Input Required: token}}"
-
+type: "Okta-1.0.0"
+adapterConfig: "ewogICAgInZlcnNpb24iOiAxLAogICAgImNvbmZpZyI6IHsKICAgICAgICAicmVxdWVzdFRpbWVvdXQiOiAiMTBzIiwKICAgICAgICAib2t0YSI6IHsKICAgICAgICAgICAgImFwaVZlcnNpb24iOiAidjEiCiAgICAgICAgfQogICAgfQp9"
+# This must match the list of supportedAuthMechanisms specified on the Adapter.
+auth:
+  - oAuth2ClientCredentials:
+      clientId: "{{Input Required: Client-ID}}"
+      tokenUrl: "https://{{Input Required: Okta-Domain}}/oauth2/v1/token"
+      authStyle: AutoDetect
+      clientSecret: "{{Input Required: Client-Secret}}"
+      scope: "okta.users.read okta.groups.read"
+  - bearer:
+      authToken: "{{Input Required: token}}"
 entities:
   User:
     displayName: OktaUser

--- a/salesforce.sgnl.yaml
+++ b/salesforce.sgnl.yaml
@@ -8,18 +8,15 @@ defaultSyncFrequency: HOURLY
 defaultSyncMinInterval: 1
 defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
-adapter:
-  hostname: "adapter.sgnl.svc.cluster.local"
-  port: 80
-  config: "ewoJInZlcnNpb24iOiAxLAoJImNvbmZpZyI6IHsKCQkicmVxdWVzdFRpbWVvdXQiOiAiMTBzIiwKCQkic2FsZXNmb3JjZSI6IHsiYXBpVmVyc2lvbiI6IjU2LjAifQoJfQp9"
-  apiVersion: "V1"
-  disableTls: true
-  auth:
-    - oAuth2ClientCredentials:
-        clientId: "{{Input Required: Client-ID}}"
-        tokenUrl: "https://{{Input Required: Tenant-Name}}.my.salesforce.com/services/oauth2/token?grant_type=client_credentials"
-        authStyle: AutoDetect
-        clientSecret: "{{Input Required: Client-Secret}}"
+type: "Salesforce-1.0.0"
+adapterConfig: "ewoJInZlcnNpb24iOiAxLAoJImNvbmZpZyI6IHsKCQkicmVxdWVzdFRpbWVvdXQiOiAiMTBzIiwKCQkic2FsZXNmb3JjZSI6IHsiYXBpVmVyc2lvbiI6IjU2LjAifQoJfQp9"
+# This must match the list of supportedAuthMechanisms specified on the Adapter.
+auth:
+  - oAuth2ClientCredentials:
+      clientId: "{{Input Required: Client-ID}}"
+      tokenUrl: "https://{{Input Required: Tenant-Name}}.my.salesforce.com/services/oauth2/token?grant_type=client_credentials"
+      authStyle: AutoDetect
+      clientSecret: "{{Input Required: Client-Secret}}"
 entities:
   Account:
     displayName: SFDCAccount

--- a/salesforce.sgnl.yaml
+++ b/salesforce.sgnl.yaml
@@ -9,6 +9,8 @@ defaultSyncMinInterval: 1
 defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
 type: "Salesforce-1.0.0"
+# Example Config:
+# {"version": 1, "config": {"requestTimeout": "10s", "salesforce": {"apiVersion":"56.0"}}}
 adapterConfig: "ewoJInZlcnNpb24iOiAxLAoJImNvbmZpZyI6IHsKCQkicmVxdWVzdFRpbWVvdXQiOiAiMTBzIiwKCQkic2FsZXNmb3JjZSI6IHsiYXBpVmVyc2lvbiI6IjU2LjAifQoJfQp9"
 # This must match the list of supportedAuthMechanisms specified on the Adapter.
 auth:

--- a/servicenow.sgnl.yaml
+++ b/servicenow.sgnl.yaml
@@ -7,16 +7,13 @@ defaultSyncFrequency: HOURLY
 defaultSyncMinInterval: 1
 defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
-adapter:
-  hostname: "adapter.sgnl.svc.cluster.local"
-  port: 80
-  config: "CnsKCSJ2ZXJzaW9uIjogMSwKCSJjb25maWciOiB7CgkJInJlcXVlc3RUaW1lb3V0IjogIjEwcyIsCgkJInNlcnZpY2Vub3ciOiB7fQoJfQp9Cg=="
-  apiVersion: "V1"
-  disableTls: true
-  auth:
-    - basic:
-        username: "{{Input Required: Username}}"
-        password: "{{Input Required: Password}}"
+type: "ServiceNow-1.0.0"
+adapterConfig: "CnsKCSJ2ZXJzaW9uIjogMSwKCSJjb25maWciOiB7CgkJInJlcXVlc3RUaW1lb3V0IjogIjEwcyIsCgkJInNlcnZpY2Vub3ciOiB7fQoJfQp9Cg=="
+# This must match the list of supportedAuthMechanisms specified on the Adapter.
+auth:
+  - basic:
+      username: "{{Input Required: Username}}"
+      password: "{{Input Required: Password}}"
 entities:
   User:
     displayName: SNOWUser

--- a/servicenow.sgnl.yaml
+++ b/servicenow.sgnl.yaml
@@ -8,6 +8,8 @@ defaultSyncMinInterval: 1
 defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
 type: "ServiceNow-1.0.0"
+# Example Config:
+# {"version": 1, "config": {"requestTimeout": "10s", "servicenow": {}}}
 adapterConfig: "CnsKCSJ2ZXJzaW9uIjogMSwKCSJjb25maWciOiB7CgkJInJlcXVlc3RUaW1lb3V0IjogIjEwcyIsCgkJInNlcnZpY2Vub3ciOiB7fQoJfQp9Cg=="
 # This must match the list of supportedAuthMechanisms specified on the Adapter.
 auth:


### PR DESCRIPTION
- Moves the `adapter.config` field to `adapterConfig`
- Moves the `adapter.auth` field to `auth`
- Adds a `type` field
- Removes the `adapter` object

This should not be merged until after the deployment on Aug 23rd. This can be merged anytime after in time for the release on Aug 30th. This should be deployed with [sc-11904](https://app.shortcut.com/sgnl/story/11904/fe-phase-4-update-sor-management-ui-to-support-adapter-resources)