### PR TITLE
[sc-13244] Add `Workspace` and `Object` entities

### DIFF
--- a/jira.sgnl.yaml
+++ b/jira.sgnl.yaml
@@ -402,6 +402,8 @@ entities:
         indexed: true
         uniqueId: true
 
+  # WARNING: In order to sync Objects, you must specify the objectsQlQuery in the adapterConfig.
+  # otherwise Jira will return 400.
   Object:
     # https://developer.atlassian.com/cloud/assets/rest/api-group-object/#api-object-aql-post.
     displayName: JiraObject

--- a/jira.sgnl.yaml
+++ b/jira.sgnl.yaml
@@ -13,7 +13,7 @@ type: "Jira-1.0.0"
 # config with issues jql filter: {"issuesJqlFilter":"project=SGNL"} | b64: "eyJpc3N1ZXNKcWxGaWx0ZXIiOiJwcm9qZWN0PVNHTkwifQ=="
 # config with issues jql filter with space {"issuesJqlFilter":"project='Customer Support'"} | b64: "eyJpc3N1ZXNKcWxGaWx0ZXIiOiJwcm9qZWN0PSdDdXN0b21lciBTdXBwb3J0JyJ9"
 # config with objects ql query {"objectsQlQuery":"objectType = Customer"} | b64: "eyJvYmplY3RzUWxRdWVyeSI6Im9iamVjdFR5cGUgPSBDdXN0b21lciJ9"
-adapterConfig: "e30="
+adapterConfig: "eyJvYmplY3RzUWxRdWVyeSI6Im9iamVjdFR5cGUgPSBJTlBVVF9SRVFVSVJFRCJ9" # {"objectsQlQuery":"objectType = INPUT_REQUIRED"}
 # This must match the list of supportedAuthMechanisms specified on the Adapter.
 auth:
   - basic:

--- a/jira.sgnl.yaml
+++ b/jira.sgnl.yaml
@@ -383,6 +383,109 @@ entities:
         type: String
         indexed: true
 
+  Workspace:
+    # https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-assets/#api-rest-servicedeskapi-assets-workspace-get.
+    displayName: JiraWorkspace
+    externalId: Workspace
+    description: Workspace entity in Jira
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: workspaceId
+        externalId: workspaceId
+        type: String
+        indexed: true
+        uniqueId: true
+
+  Asset:
+    # https://developer.atlassian.com/cloud/assets/rest/api-group-object/#api-object-aql-post.
+    displayName: JiraAsset
+    externalId: Asset
+    description: Asset entity in Jira
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: globalId
+        externalId: globalId
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: workspaceId
+        externalId: workspaceId
+        type: String
+        indexed: true
+      - name: id
+        externalId: id
+        type: String
+      - name: label
+        externalId: label
+        type: String
+      - name: objectKey
+        externalId: objectKey
+        type: String
+      - name: objectType__workspaceId
+        externalId: objectType__workspaceId
+        type: String
+      - name: objectType__globalId
+        externalId: objectType__globalId
+        type: String
+      - name: objectType__id
+        externalId: objectType__id
+        type: String
+      - name: objectType__name
+        externalId: objectType__name
+        type: String
+      - name: objectType__description
+        externalId: objectType__description
+        type: String
+      - name: objectType__position
+        externalId: objectType__position
+        type: Int64
+      - name: objectType__created
+        externalId: objectType__created
+        type: DateTime
+      - name: objectType__updated
+        externalId: objectType__updated
+        type: DateTime
+      - name: objectType__objectCount
+        externalId: objectType__objectCount
+        type: Int64
+      - name: objectType__objectSchemaId
+        externalId: objectType__objectSchemaId
+        type: String
+      - name: objectType__inherited
+        externalId: objectType__inherited
+        type: Bool
+      - name: objectType__abstractObjectType
+        externalId: objectType__abstractObjectType
+        type: Bool
+      - name: objectType__parentObjectTypeInherited
+        externalId: objectType__parentObjectTypeInherited
+        type: Bool
+      - name: created
+        externalId: created
+        type: DateTime
+      - name: updated
+        externalId: updated
+        type: DateTime
+      - name: timestamp
+        externalId: timestamp
+        type: Int64
+      - name: _links__self
+        externalId: _links__self
+        type: String
+      - name: name
+        externalId: name
+        type: String
+
 relationships:
   # (User) -[UserMember]-> (GroupMember)
   UserMember:
@@ -403,6 +506,11 @@ relationships:
         direction: Forward
       - relationship: GroupMember
         direction: Forward
+  # (Asset) -[AssetMember]-> (Workspace)
+  AssetMember:
+    name: AssetMember
+    fromAttribute: Asset.workspaceId
+    toAttribute: Workspace.workspaceId
   # (Issue) -[AssignedTo]-> (User)
   IssueAssignee:
     name: AssignedTo

--- a/jira.sgnl.yaml
+++ b/jira.sgnl.yaml
@@ -479,9 +479,10 @@ entities:
       - name: timestamp
         externalId: timestamp
         type: Int64
-      - name: _links__self
-        externalId: _links__self
-        type: String
+      # TODO: We currently don't allow attributes to be start with a non-alphanumeric char.
+      # - name: _links__self
+      #   externalId: _links__self
+      #   type: String
       - name: name
         externalId: name
         type: String

--- a/jira.sgnl.yaml
+++ b/jira.sgnl.yaml
@@ -401,11 +401,11 @@ entities:
         indexed: true
         uniqueId: true
 
-  Asset:
+  Object:
     # https://developer.atlassian.com/cloud/assets/rest/api-group-object/#api-object-aql-post.
-    displayName: JiraAsset
-    externalId: Asset
-    description: Asset entity in Jira
+    displayName: JiraObject
+    externalId: Object
+    description: Object entity in Jira
     syncFrequency: HOURLY
     syncMinInterval: 1
     apiCallFrequency: SECONDLY
@@ -506,10 +506,10 @@ relationships:
         direction: Forward
       - relationship: GroupMember
         direction: Forward
-  # (Asset) -[AssetMember]-> (Workspace)
-  AssetMember:
-    name: AssetMember
-    fromAttribute: Asset.workspaceId
+  # (Object) -[ObjectMember]-> (Workspace)
+  ObjectMember:
+    name: ObjectMember
+    fromAttribute: Object.workspaceId
     toAttribute: Workspace.workspaceId
   # (Issue) -[AssignedTo]-> (User)
   IssueAssignee:

--- a/jira.sgnl.yaml
+++ b/jira.sgnl.yaml
@@ -482,10 +482,6 @@ entities:
       - name: timestamp
         externalId: timestamp
         type: Int64
-      # TODO: We currently don't allow attributes to be start with a non-alphanumeric char.
-      # - name: _links__self
-      #   externalId: _links__self
-      #   type: String
       - name: name
         externalId: name
         type: String

--- a/jira.sgnl.yaml
+++ b/jira.sgnl.yaml
@@ -12,6 +12,7 @@ type: "Jira-1.0.0"
 # empty config: {} | b64: "e30="
 # config with issues jql filter: {"issuesJqlFilter":"project=SGNL"} | b64: "eyJpc3N1ZXNKcWxGaWx0ZXIiOiJwcm9qZWN0PVNHTkwifQ=="
 # config with issues jql filter with space {"issuesJqlFilter":"project='Customer Support'"} | b64: "eyJpc3N1ZXNKcWxGaWx0ZXIiOiJwcm9qZWN0PSdDdXN0b21lciBTdXBwb3J0JyJ9"
+# config with objects ql query {"objectsQlQuery":"objectType = Customer"} | b64: "eyJvYmplY3RzUWxRdWVyeSI6Im9iamVjdFR5cGUgPSBDdXN0b21lciJ9"
 adapterConfig: "e30="
 # This must match the list of supportedAuthMechanisms specified on the Adapter.
 auth:


### PR DESCRIPTION
Add the following new entities:

- Object
- Workspace

An object is a member of a workspace.

Create an `ObjectMember` relationships between an object and a workspace if their `workspaceId` fields match.
There is no need to create an intermediate `ObjectMember` node because an object already has a unique ID (`globalId`) which is unique for a given workspace and object.