### PR TITLE
[sc-8732] Add YAML template for Curity SoR

### DIFF
--- a/azure-ad.sgnl.yaml
+++ b/azure-ad.sgnl.yaml
@@ -12,7 +12,7 @@ type: "AzureAD-1.0.0"
 # Example Config:
 # {"version": 1, "config": {"filters": {}, "requestTimeout": "10s", "azuread": {"apiVersion": "v1.0"}}}
 adapterConfig: "ewoJInZlcnNpb24iOiAxLAoJImNvbmZpZyI6IHsKICAgICAgICAgICAgICAgICJmaWx0ZXJzIjoge30sCgkJInJlcXVlc3RUaW1lb3V0IjogIjEwcyIsCgkJImF6dXJlYWQiOiB7CiAgICAgICAgICAgICAgICAgICAgImFwaVZlcnNpb24iOiAidjEuMCIKICAgICAgICAgICAgICAgIH0KCX0KfQ=="
-# This must match the list of supportedAuthMechanisms specified on the Adapter.
+# All auth mechanisms specified below must be supported by the specified Adapter.
 auth:
   - oAuth2ClientCredentials:
       clientId: "{{Input Required: Client-ID}}"

--- a/curity.sgnl.yaml
+++ b/curity.sgnl.yaml
@@ -179,6 +179,8 @@ entities:
       - name: formatted
         externalId: formatted
         type: String
+        indexed: true
+        uniqueId: true
       - name: streetAddress
         externalId: streetAddress
         type: String
@@ -364,6 +366,6 @@ relationships:
   # Manager relationship
   UserManager:
     name: Manager
-    fromAttribute: User.managerId
-    toAttribute: User.id
+    fromAttribute: CurityUser.managerId
+    toAttribute: CurityUser.id
   

--- a/curity.sgnl.yaml
+++ b/curity.sgnl.yaml
@@ -1,0 +1,369 @@
+# Curity Configuration YAML for DS2.0
+# Note: The externalId for each entity must match the endpoint for this resource i.e. 
+# - External ID for an User entity representing a User resource (/Users) is "Users"
+# - External ID for a Group entity representing a Group resource (/Groups) is "Groups"
+
+displayName: "Curity"
+icon: TODO
+description: "Curity as a System of Record"
+address: "{{Input Required: Curity URL}}"
+defaultSyncFrequency: HOURLY
+defaultSyncMinInterval: 1
+defaultApiCallFrequency: SECONDLY
+defaultApiCallMinInterval: 1
+type: "SCIM2.0-1.0.0"
+# Example Configs:
+# empty config: {} | b64: "e30="
+# config with filtering on Users: {"Users":{"queryParams":{"filter":"displayName eq \"SGNL\""}}} | b64: "eyJVc2VycyI6eyJxdWVyeVBhcmFtcyI6eyJmaWx0ZXIiOiJkaXNwbGF5TmFtZSBlcSBcIlNHTkxcIiJ9fQ=="
+# config with filter, ordering and sortBy on Groups {"Groups":{"queryParams":{"filter":"displayName eq \"SGNL\"","sortBy":"userName","ascending":true}}} | b64: "eyJHcm91cHMiOnsicXVlcnlQYXJhbXMiOnsiZmlsdGVyIjoiZGlzcGxheU5hbWUgZXEgXCJTR05MXCIiLCJzb3J0QnkiOiJ1c2VyTmFtZSIsImFzY2VuZGluZyI6dHJ1ZX19fQ=="
+adapterConfig: "e30=" # {}
+# This must match the list of supportedAuthMechanisms specified on the Adapter.
+auth:
+  - oAuth2ClientCredentials:
+      clientId: "{{Input Required: Client-ID}}"
+      clientSecret: "{{Input Required: Client-Secret}}"
+      tokenUrl: "{{Input Required: AuthTokenURL}}"
+      scope: "{{Input Required: Scope}}"
+      authStyle: AutoDetect
+entities:
+  User:
+    displayName: CurityUser
+    externalId: Users
+    description: User entity in Curity
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: id
+        externalId: id
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: externalId
+        externalId: externalId
+        type: String
+      - name: userName
+        externalId: userName
+        type: String
+      - name: formattedName
+        externalId: $.name.formatted
+        type: String
+      - name: familyName
+        externalId: $.name.familyName
+        type: String
+      - name: givenName
+        externalId: $.name.givenName
+        type: String
+      - name: middleName
+        externalId: $.name.middleName
+        type: String
+      - name: honorificPrefix
+        externalId: $.name.honorificPrefix
+        type: String
+      - name: honorificSuffix 
+        externalId: $.name.honorificSuffix
+        type: String
+      - name: displayName
+        externalId: displayName
+        type: String
+      - name: nickName
+        externalId: nickName
+        type: String
+      - name: profileUrl
+        externalId: profileUrl    
+        type: String
+      - name: userType
+        externalId: userType
+        type: String  
+      - name: title
+        externalId: title
+        type: String
+      - name: preferredLanguage
+        externalId: preferredLanguage
+        type: String
+      - name: locale  
+        externalId: locale
+        type: String
+      - name: timezone
+        externalId: timezone
+        type: String
+      - name: active
+        externalId: active
+        type: Bool 
+      - name: password
+        externalId: password
+        type: String
+      
+      # Enterprise User Extension
+      - name: employeeNumber
+        externalId: $..["urn:ietf:params:Curity:schemas:extension:enterprise:2.0:User"].employeeNumber
+        type: String
+      - name: costCenter
+        externalId: $..["urn:ietf:params:Curity:schemas:extension:enterprise:2.0:User"].costCenter
+        type: String
+      - name: organization
+        externalId: $..["urn:ietf:params:Curity:schemas:extension:enterprise:2.0:User"].organization
+        type: String
+      - name: division
+        externalId: $..["urn:ietf:params:Curity:schemas:extension:enterprise:2.0:User"].division
+        type: String
+      - name: department
+        externalId: $..["urn:ietf:params:Curity:schemas:extension:enterprise:2.0:User"].department
+        type: String
+      - name: managerId
+        externalId: $..["urn:ietf:params:Curity:schemas:extension:enterprise:2.0:User"].manager.value
+        type: String  
+      - name: managerDisplayName
+        externalId: $..["urn:ietf:params:Curity:schemas:extension:enterprise:2.0:User"].manager.displayName
+        type: String
+      
+      # Meta
+      - name: resourceType
+        externalId: $.meta.resourceType
+        type: String
+      - name: created
+        externalId: $.meta.created
+        type: DateTime
+      - name: lastModified
+        externalId: $.meta.lastModified
+        type: DateTime
+      - name: version 
+        externalId: $.meta.version
+        type: String  
+      - name: location
+        externalId: $.meta.location
+        type: String
+
+  Email:
+    parent: Users  # External ID of the parent entity
+    displayName: CurityUserEmail
+    externalId: emails
+    description: Entity representing Curity user emails
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: value
+        externalId: value
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: display
+        externalId: display
+        type: String
+      - name: type
+        externalId: type
+        type: String
+      - name: primary
+        externalId: primary
+        type: Bool
+
+  Address:
+    parent: Users  # External ID of the parent entity
+    displayName: CurityUserAddress
+    externalId: addresses
+    description: Entity representing Curity user addresses
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: formatted
+        externalId: formatted
+        type: String
+      - name: streetAddress
+        externalId: streetAddress
+        type: String
+      - name: locality
+        externalId: locality
+        type: String
+      - name: region
+        externalId: region
+        type: String
+      - name: postalCode
+        externalId: postalCode
+        type: String
+      - name: country
+        externalId: country
+        type: String
+      - name: type
+        externalId: type
+        type: String
+
+  PhoneNumber:
+    parent: Users  # External ID of the parent entity
+    displayName: CurityUserPhoneNumber
+    externalId: phoneNumbers
+    description: Entity representing Curity user phone numbers
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: value
+        externalId: value
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: display
+        externalId: display
+        type: String
+      - name: type
+        externalId: type
+        type: String
+      - name: primary
+        externalId: primary
+        type: Bool
+
+  IMS:
+    parent: Users  # External ID of the parent entity
+    displayName: CurityUserIMS
+    externalId: ims
+    description: Entity representing Curity user ims
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: value
+        externalId: value
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: display
+        externalId: display
+        type: String  
+      - name: type
+        externalId: type
+        type: String
+      - name: primary
+        externalId: primary
+        type: Bool
+
+  Entitlement:
+    parent: Users  # External ID of the parent entity
+    displayName: CurityUserEntitlement
+    externalId: entitlements
+    description: Entity representing Curity user entitlements
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: value
+        externalId: value
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: display
+        externalId: display
+        type: String  
+      - name: type
+        externalId: type
+        type: String
+      - name: primary
+        externalId: primary
+        type: Bool
+  
+  Roles:
+    parent: Users  # External ID of the parent entity
+    displayName: CurityUserRole
+    externalId: roles
+    description: Entity representing Curity user roles
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: value
+        externalId: value
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: display
+        externalId: display
+        type: String  
+      - name: type
+        externalId: type
+        type: String
+      - name: primary
+        externalId: primary
+        type: Bool
+
+  Photo:
+    parent: Users  # External ID of the parent entity
+    displayName: CurityUserPhoto
+    externalId: photos
+    description: Entity representing Curity user photos
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: value
+        externalId: value
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: display
+        externalId: display
+        type: String  
+      - name: type
+        externalId: type
+        type: String
+      - name: primary
+        externalId: primary
+        type: Bool
+  
+  Certificates:
+    parent: Users  # External ID of the parent entity
+    displayName: CurityUserCertificate
+    externalId: certificates
+    description: Entity representing Curity user certificates
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: value
+        externalId: value
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: display
+        externalId: display
+        type: String  
+      - name: type
+        externalId: type
+        type: String
+      - name: primary
+        externalId: primary
+        type: Bool
+
+relationships:
+  # Manager relationship
+  UserManager:
+    name: Manager
+    fromAttribute: User.managerId
+    toAttribute: User.id
+  

--- a/curity.sgnl.yaml
+++ b/curity.sgnl.yaml
@@ -142,7 +142,7 @@ entities:
         type: String
 
   Email:
-    parent: Users  # External ID of the parent entity
+    parent: Users  
     displayName: CurityUserEmail
     externalId: emails
     description: Entity representing Curity user emails
@@ -169,7 +169,7 @@ entities:
         type: Bool
 
   Address:
-    parent: Users  # External ID of the parent entity
+    parent: Users  
     displayName: CurityUserAddress
     externalId: addresses
     description: Entity representing Curity user addresses
@@ -205,7 +205,7 @@ entities:
         type: String
 
   PhoneNumber:
-    parent: Users  # External ID of the parent entity
+    parent: Users  
     displayName: CurityUserPhoneNumber
     externalId: phoneNumbers
     description: Entity representing Curity user phone numbers
@@ -224,141 +224,6 @@ entities:
       - name: display
         externalId: display
         type: String
-      - name: type
-        externalId: type
-        type: String
-      - name: primary
-        externalId: primary
-        type: Bool
-
-  IMS:
-    parent: Users  # External ID of the parent entity
-    displayName: CurityUserIMS
-    externalId: ims
-    description: Entity representing Curity user ims
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
-    pageSize: 100
-    pagesOrderedById: false
-    attributes:
-      - name: value
-        externalId: value
-        type: String
-        indexed: true
-        uniqueId: true
-      - name: display
-        externalId: display
-        type: String  
-      - name: type
-        externalId: type
-        type: String
-      - name: primary
-        externalId: primary
-        type: Bool
-
-  Entitlement:
-    parent: Users  # External ID of the parent entity
-    displayName: CurityUserEntitlement
-    externalId: entitlements
-    description: Entity representing Curity user entitlements
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
-    pageSize: 100
-    pagesOrderedById: false
-    attributes:
-      - name: value
-        externalId: value
-        type: String
-        indexed: true
-        uniqueId: true
-      - name: display
-        externalId: display
-        type: String  
-      - name: type
-        externalId: type
-        type: String
-      - name: primary
-        externalId: primary
-        type: Bool
-  
-  Roles:
-    parent: Users  # External ID of the parent entity
-    displayName: CurityUserRole
-    externalId: roles
-    description: Entity representing Curity user roles
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
-    pageSize: 100
-    pagesOrderedById: false
-    attributes:
-      - name: value
-        externalId: value
-        type: String
-        indexed: true
-        uniqueId: true
-      - name: display
-        externalId: display
-        type: String  
-      - name: type
-        externalId: type
-        type: String
-      - name: primary
-        externalId: primary
-        type: Bool
-
-  Photo:
-    parent: Users  # External ID of the parent entity
-    displayName: CurityUserPhoto
-    externalId: photos
-    description: Entity representing Curity user photos
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
-    pageSize: 100
-    pagesOrderedById: false
-    attributes:
-      - name: value
-        externalId: value
-        type: String
-        indexed: true
-        uniqueId: true
-      - name: display
-        externalId: display
-        type: String  
-      - name: type
-        externalId: type
-        type: String
-      - name: primary
-        externalId: primary
-        type: Bool
-  
-  Certificates:
-    parent: Users  # External ID of the parent entity
-    displayName: CurityUserCertificate
-    externalId: certificates
-    description: Entity representing Curity user certificates
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
-    pageSize: 100
-    pagesOrderedById: false
-    attributes:
-      - name: value
-        externalId: value
-        type: String
-        indexed: true
-        uniqueId: true
-      - name: display
-        externalId: display
-        type: String  
       - name: type
         externalId: type
         type: String

--- a/curity.sgnl.yaml
+++ b/curity.sgnl.yaml
@@ -4,7 +4,7 @@
 # - External ID for a Group entity representing a Group resource (/Groups) is "Groups"
 
 displayName: "Curity"
-icon: TODO
+icon: PHN2ZyB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiBmaWxsPSIjMkIzMDNDIi8+CjxwYXRoIGQ9Ik00OS40OTYzIDM1LjczOTdMNDkuMDUzMSAzNi4xOTA4QzQ2Ljc5NjcgMzguNTg5IDQzLjY5MTcgNDAuMDA5NCA0MC40MDE5IDQwLjE0ODRDMzkuMzEyOCA0MC4xODYzIDM4LjIyNzcgMzkuOTk5IDM3LjIxNDQgMzkuNTk4MUMzNi4yMDExIDM5LjE5NzIgMzUuMjgxNSAzOC41OTE0IDM0LjUxMzIgMzcuODE4N0MzMy43NDQ5IDM3LjA0NTkgMzMuMTQ0NSAzNi4xMjI4IDMyLjc0OTUgMzUuMTA3M0MzMi4zNTQ1IDM0LjA5MTcgMzIuMTczNCAzMy4wMDU1IDMyLjIxNzcgMzEuOTE2N0MzMi4yMTc3IDI3LjE2NzYgMzUuNTczNyAyMy42OTI5IDQwLjIwNCAyMy42OTI5QzQzLjE4MDUgMjMuODA0OSA0Ni4wMzE1IDI0LjkyMDggNDguMjkzMiAyNi44NTg5TDQ4LjczNjUgMjcuMjQ2OEw1My4xNzY4IDIyLjYwODVMNTIuNjc4MiAyMi4xODExQzQ5LjAzNDEgMTkuMTY4NyA0NC40NTcgMTcuNTE1MyAzOS43MjkxIDE3LjUwMzNDMzcuMzYwMiAxNy40NTI5IDM1LjAxNDYgMTcuOTgwMSAzMi44OTUxIDE5LjAzOTJDMzAuNzc1NSAyMC4wOTgzIDI4Ljk0NTcgMjEuNjU3NSAyNy41NjM2IDIzLjU4MjFIMTkuMzcxNUwxOC44OTY2IDI3LjYxMDlIMjUuNjI0NEMyNS40MDczIDI4LjM1MTUgMjUuMjUxMiAyOS4xMDg1IDI1LjE1NzQgMjkuODc0NkgxNS4xMDUyTDE0LjYyMjQgMzMuODk1NEgyNS4xNTc0QzI1LjI0ODIgMzQuNjYwNyAyNS4zOTkgMzUuNDE3NiAyNS42MDg2IDM2LjE1OTJIMTAuNDgyOEwxMCA0MC4xODc5SDI3LjUyNEMzMC4xMjgxIDQzLjkzOTcgMzQuNTY4NCA0Ni4yNjY3IDM5LjkyNyA0Ni4yNjY3QzQ0Ljk5MTIgNDYuMjE2NiA0OS44NSA0NC4yNTc4IDUzLjUzMyA0MC43ODE2TDU0IDQwLjMzODNMNDkuNDk2MyAzNS43Mzk3WiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTEzLjk2NTUgMjkuODY2N0gxMC45OTczTDEwLjUyMjQgMzMuODk1NEgxMy40ODI2TDEzLjk2NTUgMjkuODY2N1oiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPgo=
 description: "Curity as a System of Record"
 address: "{{Input Required: Curity URL}}"
 defaultSyncFrequency: HOURLY
@@ -45,9 +45,11 @@ entities:
       - name: externalId
         externalId: externalId
         type: String
+        indexed: true
       - name: userName
         externalId: userName
         type: String
+        indexed: true
       - name: formattedName
         externalId: $.name.formatted
         type: String
@@ -99,25 +101,27 @@ entities:
       
       # Enterprise User Extension
       - name: employeeNumber
-        externalId: $..["urn:ietf:params:Curity:schemas:extension:enterprise:2.0:User"].employeeNumber
+        externalId: $..["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"].employeeNumber
         type: String
+        indexed: true
       - name: costCenter
-        externalId: $..["urn:ietf:params:Curity:schemas:extension:enterprise:2.0:User"].costCenter
+        externalId: $..["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"].costCenter
         type: String
       - name: organization
-        externalId: $..["urn:ietf:params:Curity:schemas:extension:enterprise:2.0:User"].organization
+        externalId: $..["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"].organization
         type: String
       - name: division
-        externalId: $..["urn:ietf:params:Curity:schemas:extension:enterprise:2.0:User"].division
+        externalId: $..["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"].division
         type: String
       - name: department
-        externalId: $..["urn:ietf:params:Curity:schemas:extension:enterprise:2.0:User"].department
+        externalId: $..["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"].department
         type: String
       - name: managerId
-        externalId: $..["urn:ietf:params:Curity:schemas:extension:enterprise:2.0:User"].manager.value
+        externalId: $..["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"].manager.value
         type: String  
+        indexed: true
       - name: managerDisplayName
-        externalId: $..["urn:ietf:params:Curity:schemas:extension:enterprise:2.0:User"].manager.displayName
+        externalId: $..["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"].manager.displayName
         type: String
       
       # Meta
@@ -366,6 +370,6 @@ relationships:
   # Manager relationship
   UserManager:
     name: Manager
-    fromAttribute: Users.$..["urn:ietf:params:Curity:schemas:extension:enterprise:2.0:User"].manager.value
+    fromAttribute: Users.$..["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"].manager.value
     toAttribute: Users.id
   

--- a/curity.sgnl.yaml
+++ b/curity.sgnl.yaml
@@ -17,7 +17,7 @@ type: "SCIM2.0-1.0.0"
 # config with filtering on Users: {"Users":{"queryParams":{"filter":"displayName eq \"SGNL\""}}} | b64: "eyJVc2VycyI6eyJxdWVyeVBhcmFtcyI6eyJmaWx0ZXIiOiJkaXNwbGF5TmFtZSBlcSBcIlNHTkxcIiJ9fQ=="
 # config with filter, ordering and sortBy on Groups {"Groups":{"queryParams":{"filter":"displayName eq \"SGNL\"","sortBy":"userName","ascending":true}}} | b64: "eyJHcm91cHMiOnsicXVlcnlQYXJhbXMiOnsiZmlsdGVyIjoiZGlzcGxheU5hbWUgZXEgXCJTR05MXCIiLCJzb3J0QnkiOiJ1c2VyTmFtZSIsImFzY2VuZGluZyI6dHJ1ZX19fQ=="
 adapterConfig: "e30=" # {}
-# This must match the list of supportedAuthMechanisms specified on the Adapter.
+# All auth mechanisms specified below must be supported by the specified Adapter.
 auth:
   - oAuth2ClientCredentials:
       clientId: "{{Input Required: Client-ID}}"

--- a/curity.sgnl.yaml
+++ b/curity.sgnl.yaml
@@ -366,6 +366,6 @@ relationships:
   # Manager relationship
   UserManager:
     name: Manager
-    fromAttribute: CurityUser.managerId
-    toAttribute: CurityUser.id
+    fromAttribute: Users.$..["urn:ietf:params:Curity:schemas:extension:enterprise:2.0:User"].manager.value
+    toAttribute: Users.id
   

--- a/curity.sgnl.yaml
+++ b/curity.sgnl.yaml
@@ -95,9 +95,6 @@ entities:
       - name: active
         externalId: active
         type: Bool 
-      - name: password
-        externalId: password
-        type: String
       
       # Enterprise User Extension
       - name: employeeNumber
@@ -146,10 +143,6 @@ entities:
     displayName: CurityUserEmail
     externalId: emails
     description: Entity representing Curity user emails
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -173,10 +166,6 @@ entities:
     displayName: CurityUserAddress
     externalId: addresses
     description: Entity representing Curity user addresses
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -209,10 +198,6 @@ entities:
     displayName: CurityUserPhoneNumber
     externalId: phoneNumbers
     description: Entity representing Curity user phone numbers
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:

--- a/custom.sgnl.yaml
+++ b/custom.sgnl.yaml
@@ -8,7 +8,7 @@ defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
 type: "{{Input Required: SoR-Type}}"
 adapterConfig: "e30="
-# This must match the list of supportedAuthMechanisms specified on the Adapter.
+# All auth mechanisms specified below must be supported by the specified Adapter.
 auth:
   - oAuth2ClientCredentials:
       clientId: "{{Input Required: Client-ID}}"

--- a/jira.sgnl.yaml
+++ b/jira.sgnl.yaml
@@ -14,7 +14,7 @@ type: "Jira-1.0.0"
 # config with issues jql filter with space {"issuesJqlFilter":"project='Customer Support'"} | b64: "eyJpc3N1ZXNKcWxGaWx0ZXIiOiJwcm9qZWN0PSdDdXN0b21lciBTdXBwb3J0JyJ9"
 # config with objects ql query {"objectsQlQuery":"objectType = Customer"} | b64: "eyJvYmplY3RzUWxRdWVyeSI6Im9iamVjdFR5cGUgPSBDdXN0b21lciJ9"
 adapterConfig: "eyJvYmplY3RzUWxRdWVyeSI6Im9iamVjdFR5cGUgPSBJTlBVVF9SRVFVSVJFRCJ9" # {"objectsQlQuery":"objectType = INPUT_REQUIRED"}
-# This must match the list of supportedAuthMechanisms specified on the Adapter.
+# All auth mechanisms specified below must be supported by the specified Adapter.
 auth:
   - basic:
       username: "{{Input Required: Username}}"

--- a/okta.sgnl.yaml
+++ b/okta.sgnl.yaml
@@ -12,7 +12,7 @@ type: "Okta-1.0.0"
 # Example Config:
 # {"version": 1, "config": {"requestTimeout": "10s", "okta": {"apiVersion": "v1"}}}
 adapterConfig: "ewogICAgInZlcnNpb24iOiAxLAogICAgImNvbmZpZyI6IHsKICAgICAgICAicmVxdWVzdFRpbWVvdXQiOiAiMTBzIiwKICAgICAgICAib2t0YSI6IHsKICAgICAgICAgICAgImFwaVZlcnNpb24iOiAidjEiCiAgICAgICAgfQogICAgfQp9"
-# This must match the list of supportedAuthMechanisms specified on the Adapter.
+# All auth mechanisms specified below must be supported by the specified Adapter.
 auth:
   - oAuth2ClientCredentials:
       clientId: "{{Input Required: Client-ID}}"

--- a/pagerduty.sgnl.yaml
+++ b/pagerduty.sgnl.yaml
@@ -18,7 +18,7 @@ type: "PagerDuty-1.0.0"
 # }
 # Each param value must either be []string or string.
 adapterConfig: "e30="
-# This must match the list of supportedAuthMechanisms specified on the Adapter.
+# All auth mechanisms specified below must be supported by the specified Adapter.
 auth:
   - bearer:
       authToken: "Token token={{Input Required: token}}"

--- a/salesforce.sgnl.yaml
+++ b/salesforce.sgnl.yaml
@@ -12,7 +12,7 @@ type: "Salesforce-1.0.0"
 # Example Config:
 # {"version": 1, "config": {"requestTimeout": "10s", "salesforce": {"apiVersion":"56.0"}}}
 adapterConfig: "ewoJInZlcnNpb24iOiAxLAoJImNvbmZpZyI6IHsKCQkicmVxdWVzdFRpbWVvdXQiOiAiMTBzIiwKCQkic2FsZXNmb3JjZSI6IHsiYXBpVmVyc2lvbiI6IjU2LjAifQoJfQp9"
-# This must match the list of supportedAuthMechanisms specified on the Adapter.
+# All auth mechanisms specified below must be supported by the specified Adapter.
 auth:
   - oAuth2ClientCredentials:
       clientId: "{{Input Required: Client-ID}}"

--- a/servicenow.sgnl.yaml
+++ b/servicenow.sgnl.yaml
@@ -11,7 +11,7 @@ type: "ServiceNow-1.0.0"
 # Example Config:
 # {"version": 1, "config": {"requestTimeout": "10s", "servicenow": {}}}
 adapterConfig: "CnsKCSJ2ZXJzaW9uIjogMSwKCSJjb25maWciOiB7CgkJInJlcXVlc3RUaW1lb3V0IjogIjEwcyIsCgkJInNlcnZpY2Vub3ciOiB7fQoJfQp9Cg=="
-# This must match the list of supportedAuthMechanisms specified on the Adapter.
+# All auth mechanisms specified below must be supported by the specified Adapter.
 auth:
   - basic:
       username: "{{Input Required: Username}}"


### PR DESCRIPTION
This PR adds a Curity template that contains the `User` entity and it's child entities (emails, addresses and phonenumbers) from the SCIM template as the base (https://app.shortcut.com/sgnl/story/8732/curity-template-scim#activity-17005). This template uses the `SCIM2.0-1.0.0` adapter.