### PR TITLE
[sc-16211] Add YAML template for Sailpoint SoR

### DIFF
--- a/sailpoint.sgnl.yaml
+++ b/sailpoint.sgnl.yaml
@@ -1233,7 +1233,7 @@ entities:
       - name: regionOwnerRef
         externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].regionOwner..["$ref"]
         type: String
-      - name: location
+      - name: locationName
         externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].location
         type: String
       - name: locationOwnerDisplayName

--- a/sailpoint.sgnl.yaml
+++ b/sailpoint.sgnl.yaml
@@ -1033,7 +1033,7 @@ entities:
       - name: effective
         externalId: effective
         type: Bool
-      
+
   TaskResult:
     displayName: SailpointTaskResult
     externalId: TaskResults

--- a/sailpoint.sgnl.yaml
+++ b/sailpoint.sgnl.yaml
@@ -1,5 +1,5 @@
 # Sailpoint 2.0 Configuration YAML for DS2.0
-# Note: The externalId for each entity must match the endpoint for this resource i.e. 
+# Note: The externalId for each entity must match the endpoint for this resource i.e.
 # - External ID for an User entity representing a User resource (/Users) is "Users"
 # - External ID for a Group entity representing a Group resource (/Groups) is "Groups"
 
@@ -90,7 +90,7 @@ entities:
       - name: applicationDisplayName
         externalId: application.displayName
         type: String
-      
+
       # Meta
       - name: resourceType
         externalId: $.meta.resourceType
@@ -101,9 +101,9 @@ entities:
       - name: lastModified
         externalId: $.meta.lastModified
         type: DateTime
-      - name: version 
+      - name: version
         externalId: $.meta.version
-        type: String  
+        type: String
       - name: location
         externalId: $.meta.location
         type: String
@@ -158,7 +158,7 @@ entities:
       - name: targetDisplayName
         externalId: targetDisplayName
         type: String
-      
+
       # Meta
       - name: resourceType
         externalId: $.meta.resourceType
@@ -169,13 +169,13 @@ entities:
       - name: lastModified
         externalId: $.meta.lastModified
         type: DateTime
-      - name: version 
+      - name: version
         externalId: $.meta.version
-        type: String  
+        type: String
       - name: location
         externalId: $.meta.location
         type: String
-  
+
   # TODO: Identify unique and index attributes
   AlertAttributes:
     parent: Alert
@@ -193,7 +193,7 @@ entities:
       - name: value
         externalId: value
         type: String
-  
+
   AlertActions:
     parent: Alert
     displayName: SailpointAlertActions
@@ -217,7 +217,7 @@ entities:
         uniqueId: true
 
   AlertActionResult:
-    parent: actions 
+    parent: actions
     displayName: SailpointAlertActionResultNotifications
     externalId: result
     description: Entity representing the result associated with the Sailpoint Identity IQ Alert Action.
@@ -236,7 +236,7 @@ entities:
         uniqueId: true
 
   AlertActionResultNotifications:
-    parent: result 
+    parent: result
     displayName: SailpointAlertActionResultNotifications
     externalId: notifications
     description: Entity representing the notifications associated with the Sailpoint Identity IQ Alert Action Result.
@@ -291,7 +291,7 @@ entities:
       - name: ownerDisplayName
         externalId: owner.displayName
         type: String
-      
+
       # Meta
       - name: resourceType
         externalId: $.meta.resourceType
@@ -302,9 +302,9 @@ entities:
       - name: lastModified
         externalId: $.meta.lastModified
         type: DateTime
-      - name: version 
+      - name: version
         externalId: $.meta.version
-        type: String  
+        type: String
       - name: location
         externalId: $.meta.location
         type: String
@@ -344,7 +344,7 @@ entities:
     apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
-    attributes: 
+    attributes:
       - name: locale
         externalId: locale
         type: String
@@ -418,7 +418,7 @@ entities:
       - name: reviewerRef
         externalId: reviewer.["$ref"]
         type: String
-      
+
       # Meta
       - name: resourceType
         externalId: $.meta.resourceType
@@ -429,13 +429,13 @@ entities:
       - name: lastModified
         externalId: $.meta.lastModified
         type: DateTime
-      - name: version 
+      - name: version
         externalId: $.meta.version
-        type: String  
+        type: String
       - name: location
         externalId: $.meta.location
         type: String
-  
+
   # TODO: Identify unique and index attributes
   EntitlementClassifications:
     parent: Entitlements
@@ -448,7 +448,7 @@ entities:
     apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
-    attributes: 
+    attributes:
       - name: source
         externalId: source
         type: String
@@ -479,7 +479,7 @@ entities:
     apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
-    attributes: 
+    attributes:
       - name: locale
         externalId: locale
         type: String
@@ -512,7 +512,7 @@ entities:
       - name: ref
         externalId: $..["$ref"]
         type: String
-        
+
   EntitlementOwner:
     parent: Entitlements
     displayName: SailpointEntitlementOwner
@@ -524,7 +524,7 @@ entities:
     apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
-    attributes: 
+    attributes:
       - name: value
         externalId: value
         type: String
@@ -612,7 +612,7 @@ entities:
       - name: launcher
         externalId: launcher
         type: String
-      
+
       # Meta
       - name: resourceType
         externalId: $.meta.resourceType
@@ -623,13 +623,13 @@ entities:
       - name: lastModified
         externalId: $.meta.lastModified
         type: DateTime
-      - name: version 
+      - name: version
         externalId: $.meta.version
-        type: String  
+        type: String
       - name: location
         externalId: $.meta.location
         type: String
-      
+
   # TODO: Identify unique and index attributes
   LaunchedWorkflowInput:
     parent: LaunchedWorkflows
@@ -653,13 +653,13 @@ entities:
       - name: type
         externalId: type
         type: String
-  
+
   # TODO: Identify unique and index attributes
   LaunchedWorkflowOutput:
     parent: LaunchedWorkflows
     displayName: SailpointLaunchedWorkflowOutput
     externalId: output
-    description:  Entity representing the outputs to a Sailpoint Identity IQ Launched Workflow.
+    description: Entity representing the outputs to a Sailpoint Identity IQ Launched Workflow.
     syncFrequency: HOURLY
     syncMinInterval: 1
     apiCallFrequency: SECONDLY
@@ -677,7 +677,7 @@ entities:
       - name: type
         externalId: type
         type: String
-  
+
   # TODO: Identify unique and index attributes
   LaunchedWorkflowAttributes:
     parent: LaunchedWorkflows
@@ -715,7 +715,7 @@ entities:
       - name: name
         externalId: name
         type: String
-        
+
       # Meta
       - name: resourceType
         externalId: $.meta.resourceType
@@ -726,13 +726,13 @@ entities:
       - name: lastModified
         externalId: $.meta.lastModified
         type: DateTime
-      - name: version 
+      - name: version
         externalId: $.meta.version
-        type: String  
+        type: String
       - name: location
         externalId: $.meta.location
         type: String
-  
+
   # TODO: Identify unique and index attributes
   ObjectConfigAttributes:
     parent: ObjectConfigs
@@ -782,7 +782,7 @@ entities:
       - name: editMode
         externalId: editMode
         type: String
-  
+
   # TODO: Identify unique and index attributes
   ObjectAttributeSources:
     parent: objectAttributes
@@ -811,7 +811,7 @@ entities:
 
   # TODO: Identify unique and index attributes
   ObjectAttributeTargets:
-    parent : objectAttributes 
+    parent: objectAttributes
     displayName: SailpointObjectAttributeTargets
     externalId: attributeTargets
     description: Entity representing the attribute targets associated with a Sailpoint Identity IQ ObjectConfig.
@@ -868,7 +868,7 @@ entities:
         type: String
       - name: identityDisplayName
         externalId: identity.displayName
-        type: String   
+        type: String
       - name: ownerValue
         externalId: owner.value
         type: String
@@ -884,7 +884,7 @@ entities:
       - name: status
         externalId: status
         type: String
-        
+
       # Meta
       - name: resourceType
         externalId: $.meta.resourceType
@@ -895,9 +895,9 @@ entities:
       - name: lastModified
         externalId: $.meta.lastModified
         type: DateTime
-      - name: version 
+      - name: version
         externalId: $.meta.version
-        type: String  
+        type: String
       - name: location
         externalId: $.meta.location
         type: String
@@ -942,7 +942,7 @@ entities:
         type: String
       - name: typeAutoAssignment
         externalId: type.autoAssignment
-        type: Bool 
+        type: Bool
       - name: typeAssignmentSelector
         externalId: type.assignmentSelector
         type: Bool
@@ -963,11 +963,11 @@ entities:
         type: String
       - name: ownerValue
         externalId: owner.value
-        type: String  
+        type: String
       - name: ownerRef
         externalId: owner.["$ref"]
         type: String
-        
+
       # Meta
       - name: resourceType
         externalId: $.meta.resourceType
@@ -978,9 +978,9 @@ entities:
       - name: lastModified
         externalId: $.meta.lastModified
         type: DateTime
-      - name: version 
+      - name: version
         externalId: $.meta.version
-        type: String  
+        type: String
       - name: location
         externalId: $.meta.location
         type: String
@@ -1026,7 +1026,7 @@ entities:
       - name: ref
         externalId: $..["$ref"]
         type: String
-  
+
   # TODO: Identify unique and index attributes
   RoleRequirements:
     parent: Roles
@@ -1102,7 +1102,7 @@ entities:
         externalId: classification.type
         type: String
 
-  # TODO: Skip ingestion of this entity?  
+  # TODO: Skip ingestion of this entity?
   # TODO: Identify unique and index attributes
   ServiceProviderConfiguration:
     displayName: SailpointServiceProviderConfiguration
@@ -1140,10 +1140,10 @@ entities:
       - name: changePasswordSupported
         externalId: changePassword.supported
         type: Bool
-      - name: sortSupported 
+      - name: sortSupported
         externalId: sort.supported
         type: Bool
-  
+
   # TODO: Identify unique and index attributes
   ServiceProviderConfigAuthenticationScheme:
     parent: ServiceProviderConfig
@@ -1161,13 +1161,13 @@ entities:
       - name: description
         externalId: description
         type: String
-      - name: specUri 
+      - name: specUri
         externalId: specUri
         type: String
       - name: documentationUri
         externalId: documentationUri
         type: String
-      - name: type  
+      - name: type
         externalId: type
         type: String
 
@@ -1205,7 +1205,7 @@ entities:
       - name: targetClass
         externalId: targetClass
         type: String
-      - name: targetName  
+      - name: targetName
         externalId: targetName
         type: String
       - name: terminated
@@ -1216,13 +1216,13 @@ entities:
         type: Bool
       - name: launched
         externalId: launched
-        type: DateTime  
+        type: DateTime
       - name: completed
         externalId: completed
         type: DateTime
       - name: expiration
         externalId: expiration
-        type: DateTime  
+        type: DateTime
       - name: verified
         externalId: verified
         type: DateTime
@@ -1239,9 +1239,9 @@ entities:
         externalId: taskSchedule
         type: String
       - name: messages
-        externalId: $.messages[*].[*]  # Flatten a [][]string to a []string
+        externalId: $.messages[*].[*] # Flatten a [][]string to a []string
         type: String
-      
+
       # Meta
       - name: resourceType
         externalId: $.meta.resourceType
@@ -1252,9 +1252,9 @@ entities:
       - name: lastModified
         externalId: $.meta.lastModified
         type: DateTime
-      - name: version 
+      - name: version
         externalId: $.meta.version
-        type: String  
+        type: String
       - name: location
         externalId: $.meta.location
         type: String
@@ -1300,7 +1300,7 @@ entities:
         type: String
       - name: familyName
         externalId: name.familyName
-        type: String  
+        type: String
       - name: givenName
         externalId: name.givenName
         type: String
@@ -1317,7 +1317,7 @@ entities:
       # Enterprise extension
       - name: managerId
         externalId: $..["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"].manager.value
-        type: String  
+        type: String
         indexed: true
       - name: managerDisplayName
         externalId: $..["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"].manager.displayName
@@ -1325,7 +1325,7 @@ entities:
       - name: managerRef
         externalId: $..["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"].manager.["$ref"]
         type: String
-      
+
       # Sailpoint user extension
       - name: capabilities
         externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].capabilities
@@ -1367,7 +1367,7 @@ entities:
       - name: regionOwnerRef
         externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].regionOwner.["$ref"]
         type: String
-      - name: location 
+      - name: location
         externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].location
         type: String
       - name: locationOwnerDisplayName
@@ -1392,7 +1392,7 @@ entities:
       - name: lastRefresh
         externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].lastRefresh
         type: DateTime
-      
+
       # Meta
       - name: resourceType
         externalId: $.meta.resourceType
@@ -1403,9 +1403,9 @@ entities:
       - name: lastModified
         externalId: $.meta.lastModified
         type: DateTime
-      - name: version 
+      - name: version
         externalId: $.meta.version
-        type: String  
+        type: String
       - name: location
         externalId: $.meta.location
         type: String
@@ -1556,7 +1556,7 @@ entities:
       - name: handler
         externalId: handler
         type: String
-      
+
       # Meta
       - name: resourceType
         externalId: $.meta.resourceType
@@ -1567,10 +1567,9 @@ entities:
       - name: lastModified
         externalId: $.meta.lastModified
         type: DateTime
-      - name: version 
+      - name: version
         externalId: $.meta.version
-        type: String  
+        type: String
       - name: location
         externalId: $.meta.location
         type: String
-  

--- a/sailpoint.sgnl.yaml
+++ b/sailpoint.sgnl.yaml
@@ -70,7 +70,7 @@ entities:
         externalId: hasEntitlements
         type: Bool
       - name: identityValue
-        externalId: identity.value
+        externalId: $.identity.value
         type: String
       - name: identityRef
         externalId: $.identity.ref
@@ -140,7 +140,7 @@ entities:
         externalId: $.application..["$ref"]
         type: String
       - name: applicationDisplayName
-        externalId: application.displayName
+        externalId: $.application.displayName
         type: String
       - name: alertDate
         externalId: alertDate
@@ -179,7 +179,7 @@ entities:
         type: String
 
   AlertAttribute:
-    parent: Alert
+    parent: Alerts
     displayName: SailpointAlertAttributes
     externalId: attributes
     description: Entity representing the attibutes associated with the Sailpoint Identity IQ Alert.
@@ -196,7 +196,7 @@ entities:
         type: String
 
   AlertAction:
-    parent: Alert
+    parent: Alerts
     displayName: SailpointAlertActions
     externalId: actions
     description: Entity representing the actions associated with the Sailpoint Identity IQ Alert.
@@ -333,13 +333,13 @@ entities:
     pageSize: 100
     pagesOrderedById: false
     attributes:
-      - name: value
-        externalId: value
-        type: String
-        indexed: true
-        uniqueId: true
       - name: locale
         externalId: locale
+        type: String
+        uniqueId: true
+        indexed: true
+      - name: value
+        externalId: value
         type: String
 
   Entitlement:
@@ -453,13 +453,13 @@ entities:
     pageSize: 100
     pagesOrderedById: false
     attributes:
-      - name: value
-        externalId: value
+      - name: locale
+        externalId: locale
         type: String
         indexed: true
         uniqueId: true
-      - name: locale
-        externalId: locale
+      - name: value
+        externalId: value
         type: String
 
   EntitlementApplication:
@@ -598,7 +598,7 @@ entities:
     parent: LaunchedWorkflows
     displayName: SailpointLaunchedWorkflowInput
     externalId: input
-    description: Entity representing the inputs to a Sailpoint Identity IQ Launched Workflow.
+    description: Entity representing the inputs associated with a Sailpoint Identity IQ Launched Workflow.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -618,7 +618,7 @@ entities:
     parent: LaunchedWorkflows
     displayName: SailpointLaunchedWorkflowOutput
     externalId: output
-    description: Entity representing the outputs to a Sailpoint Identity IQ Launched Workflow.
+    description: Entity representing the outputs associated with a Sailpoint Identity IQ Launched Workflow.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -638,7 +638,7 @@ entities:
     parent: LaunchedWorkflows
     displayName: SailpointLaunchedWorkflowAttributes
     externalId: attributes
-    description: Entity representing the Sailpoint alert attributes each user is associated with.
+    description: Entity representing the attributes associated with a Sailpoint Identity IQ Launched Workflow.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -910,7 +910,7 @@ entities:
         externalId: $.owner.value
         type: String
       - name: ownerRef
-        externalId: $.owner..$.["$ref"]
+        externalId: $.owner..$..["$ref"]
         type: String
 
       # Meta
@@ -941,6 +941,8 @@ entities:
       - name: locale
         externalId: locale
         type: String
+        uniqueId: true
+        indexed: true
       - name: value
         externalId: value
         type: String

--- a/sailpoint.sgnl.yaml
+++ b/sailpoint.sgnl.yaml
@@ -910,7 +910,7 @@ entities:
         externalId: $.owner.value
         type: String
       - name: ownerRef
-        externalId: $.owner..$..["$ref"]
+        externalId: $.owner..["$ref"]
         type: String
 
       # Meta

--- a/sailpoint.sgnl.yaml
+++ b/sailpoint.sgnl.yaml
@@ -3,7 +3,7 @@
 # - External ID for an User entity representing a User resource (/Users) is "Users"
 # - External ID for a Group entity representing a Group resource (/Groups) is "Groups"
 
-displayName: "SailPoint"
+displayName: "Sailpoint"
 icon: PHN2ZyB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTQwLjQxMTggNDIuMTM3M0gxMEwzNS4yMzUzIDEwTDQwLjQxMTggNDIuMTM3M1oiIGZpbGw9IiMwMDMzQTEiLz4KPHBhdGggZD0iTTQwLjQxMTggNDIuMTM3M0g1NEwzNS4yMzUzIDEwTDQwLjQxMTggNDIuMTM3M1oiIGZpbGw9IiNDQzI3QjAiLz4KPHBhdGggZD0iTTQwLjQxMTggNDIuMTM3M0gxMEw0Mi4zNTI5IDUzLjc4NDNMNDAuNDExOCA0Mi4xMzczWiIgZmlsbD0iIzAwNzFDRSIvPgo8cGF0aCBkPSJNNDAuNDExOCA0Mi4xMzczSDU0TDQyLjM1MjkgNTMuNzg0M0w0MC40MTE4IDQyLjEzNzNaIiBmaWxsPSIjRTE3RkQyIi8+Cjwvc3ZnPgo=
 description: "Sailpoint as a System of Record"
 address: "{{Input Required: Sailpoint URL}}"
@@ -11,13 +11,13 @@ defaultSyncFrequency: HOURLY
 defaultSyncMinInterval: 1
 defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
-type: "Sailpoint2.0-1.0.0"
+type: "SCIM2.0-1.0.0"
 # Example Configs:
 # empty config: {} | b64: "e30="
 # config with filtering on Users: {"Users":{"queryParams":{"filter":"displayName eq \"SGNL\""}}} | b64: "eyJVc2VycyI6eyJxdWVyeVBhcmFtcyI6eyJmaWx0ZXIiOiJkaXNwbGF5TmFtZSBlcSBcIlNHTkxcIiJ9fQ=="
 # config with filter, ordering and sortBy on Groups {"Groups":{"queryParams":{"filter":"displayName eq \"SGNL\"","sortBy":"userName","ascending":true}}} | b64: "eyJHcm91cHMiOnsicXVlcnlQYXJhbXMiOnsiZmlsdGVyIjoiZGlzcGxheU5hbWUgZXEgXCJTR05MXCIiLCJzb3J0QnkiOiJ1c2VyTmFtZSIsImFzY2VuZGluZyI6dHJ1ZX19fQ=="
 adapterConfig: "e30=" # {}
-# This must match the list of supportedAuthMechanisms specified on the Adapter.
+# All auth mechanisms specified below must be supported by the specified Adapter.
 auth:
   - basic:
       username: "{{Input Required: Username}}"
@@ -73,22 +73,22 @@ entities:
         externalId: identity.value
         type: String
       - name: identityRef
-        externalId: identity.["$ref"]
+        externalId: $.identity.ref
         type: String
       - name: identityUserName
-        externalId: identity.userName
+        externalId: $.identity.userName
         type: String
       - name: identityDisplayName
-        externalId: identity.displayName
+        externalId: $.identity.displayName
         type: String
       - name: applicationValue
-        externalId: application.value
+        externalId: $.application.value
         type: String
       - name: applicationRef
-        externalId: application.["$ref"]
+        externalId: $.application.ref
         type: String
       - name: applicationDisplayName
-        externalId: application.displayName
+        externalId: $.application.displayName
         type: String
 
       # Meta
@@ -116,6 +116,8 @@ entities:
     syncMinInterval: 1
     apiCallFrequency: SECONDLY
     apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
     attributes:
       - name: id
         externalId: id
@@ -132,10 +134,10 @@ entities:
         externalId: type
         type: String
       - name: applicationValue
-        externalId: application.value
+        externalId: $.application.value
         type: String
       - name: applicationRef
-        externalId: application.["$ref"]
+        externalId: $.application..["$ref"]
         type: String
       - name: applicationDisplayName
         externalId: application.displayName
@@ -177,15 +179,13 @@ entities:
         type: String
 
   # TODO: Identify unique and index attributes
-  AlertAttributes:
+  AlertAttribute:
     parent: Alert
     displayName: SailpointAlertAttributes
     externalId: attributes
     description: Entity representing the attibutes associated with the Sailpoint Identity IQ Alert.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
     attributes:
       - name: key
         externalId: key
@@ -194,68 +194,62 @@ entities:
         externalId: value
         type: String
 
-  AlertActions:
+  AlertAction:
     parent: Alert
     displayName: SailpointAlertActions
     externalId: actions
     description: Entity representing the actions associated with the Sailpoint Identity IQ Alert.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
     attributes:
+      - name: resultId
+        externalId: resultId
+        type: String
+        indexed: true
+        uniqueId: true
       - name: type
         externalId: type
         type: String
       - name: alertDefinitionName
         externalId: alertDefinitionName
         type: String
-      - name: resultId
-        externalId: result.id
-        type: String
-        indexed: true
-        uniqueId: true
 
   AlertActionResult:
     parent: actions
     displayName: SailpointAlertActionResultNotifications
     externalId: result
     description: Entity representing the result associated with the Sailpoint Identity IQ Alert Action.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
     attributes:
-      - name: name
-        externalId: name
-        type: String
       - name: workflowName
         externalId: workflowName
         type: String
         indexed: true
         uniqueId: true
+      - name: name
+        externalId: name
+        type: String
 
-  AlertActionResultNotifications:
+  AlertActionResultNotification:
     parent: result
     displayName: SailpointAlertActionResultNotifications
     externalId: notifications
     description: Entity representing the notifications associated with the Sailpoint Identity IQ Alert Action Result.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
     attributes:
+      - name: emailAddresses
+        externalId: emailAddresses
+        type: String
+        indexed: true
+        uniqueId: true
       - name: name
         externalId: name
         type: String
       - name: displayName
         externalId: displayName
         type: String
-      - name: emailAddresses
-        externalId: emailAddresses
-        type: String
-        indexed: true
-        uniqueId: true
 
   Applications:
     displayName: SailpointApplication
@@ -281,15 +275,16 @@ entities:
         type: String
       - name: features
         externalId: features
+        list: true
         type: String
       - name: ownerValue
-        externalId: owner.value
+        externalId: $.owner.value
         type: String
       - name: ownerRef
-        externalId: owner.["$ref"]
+        externalId: $.owner..["$ref"]
         type: String
       - name: ownerDisplayName
-        externalId: owner.displayName
+        externalId: $.owner.displayName
         type: String
 
       # Meta
@@ -309,15 +304,11 @@ entities:
         externalId: $.meta.location
         type: String
 
-  ApplicationSchemas:
+  ApplicationSchema:
     parent: Applications
     displayName: SailpointApplicationSchemas
     externalId: applicationSchemas
     description: Entity representing the schema associated with a Sailpoint Identity IQ Application.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -333,26 +324,22 @@ entities:
         externalId: $..["$ref"]
         type: String
 
-  ApplicationLocalizedDescriptions:
+  ApplicationLocalizedDescription:
     parent: Applications
     displayName: SailpointApplicationLocalizedDescriptions
     externalId: descriptions
     description: Entity representing the localized descriptions associated with a Sailpoint Identity IQ Application.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
-      - name: locale
-        externalId: locale
-        type: String
       - name: value
         externalId: value
         type: String
         indexed: true
         uniqueId: true
+      - name: locale
+        externalId: locale
+        type: String
 
   Entitlement:
     displayName: SailpointEntitlement
@@ -394,12 +381,33 @@ entities:
       - name: lastTargetAggregation
         externalId: lastTargetAggregation
         type: DateTime
+      - name: classificationSource
+        externalId: $.classifications.source
+        type: String
+      - name: classificationEffective
+        externalId: $.classifications.effective
+        type: Bool
+      - name: classificationName
+        externalId: $.classifications.classification.name
+        type: String
+      - name: classificationDisplayName
+        externalId: $.classifications.classification.displayName
+        type: String
+      - name: classificationOrigin
+        externalId: $.classifications.classification.origin
+        type: String
+      - name: classificationType
+        externalId: $.classifications.classification.type
+        type: String
       - name: entitleAuth
         externalId: entitleAuth
         type: String
       - name: entDate
         externalId: entDate
         type: DateTime
+      - name: active
+        externalId: active
+        type: Bool
       - name: rank
         externalId: rank
         type: Int64
@@ -410,13 +418,13 @@ entities:
         externalId: email
         type: String
       - name: reviewerDisplayName
-        externalId: reviewer.displayName
+        externalId: $.reviewer.displayName
         type: String
       - name: reviewerValue
-        externalId: reviewer.value
+        externalId: $.reviewer.value
         type: String
       - name: reviewerRef
-        externalId: reviewer.["$ref"]
+        externalId: $.reviewer..["$ref"]
         type: String
 
       # Meta
@@ -436,68 +444,28 @@ entities:
         externalId: $.meta.location
         type: String
 
-  # TODO: Identify unique and index attributes
-  EntitlementClassifications:
-    parent: Entitlements
-    displayName: SailpointEntitlementClassifications
-    externalId: classifications
-    description: Entity representing a classification associated with a Sailpoint Identity IQ Entitlement.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
-    pageSize: 100
-    pagesOrderedById: false
-    attributes:
-      - name: source
-        externalId: source
-        type: String
-      - name: effective
-        externalId: effective
-        type: Bool
-      - name: classificationName
-        externalId: classification.name
-        type: String
-      - name: classificationDisplayName
-        externalId: classification.displayName
-        type: String
-      - name: classificationOrigin
-        externalId: classification.origin
-        type: String
-      - name: classificationType
-        externalId: classification.type
-        type: String
-
-  EntitlementLocalizedDescriptions:
+  EntitlementLocalizedDescription:
     parent: Entitlements
     displayName: SailpointEntitlementLocalizedDescriptions
     externalId: descriptions
     description: Entity representing the localized descriptions associated with a Sailpoint Identity IQ Entitlement.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
-      - name: locale
-        externalId: locale
-        type: String
       - name: value
         externalId: value
         type: String
         indexed: true
         uniqueId: true
+      - name: locale
+        externalId: locale
+        type: String
 
   EntitlementApplication:
     parent: Entitlements
     displayName: SailpointEntitlementApplications
     externalId: application
     description: Entity representing the application associated with a Sailpoint Identity IQ Entitlement.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -518,10 +486,6 @@ entities:
     displayName: SailpointEntitlementOwner
     externalId: owner
     description: Entity representing the owner associated with a Sailpoint Identity IQ Entitlement.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -547,8 +511,12 @@ entities:
     apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
-
     attributes:
+      - name: id
+        externalId: id
+        type: String
+        uniqueId: true
+        indexed: true
       - name: partitioned
         externalId: partitioned
         type: Bool
@@ -595,11 +563,6 @@ entities:
         externalId: $.messages[*].[*] # Flatten a [][]string to a []string
         type: String
         list: true
-      - name: id
-        externalId: id
-        type: String
-        uniqueId: true
-        indexed: true
       - name: completionStatus
         externalId: completionStatus
         type: String
@@ -636,11 +599,6 @@ entities:
     displayName: SailpointLaunchedWorkflowInput
     externalId: input
     description: Entity representing the inputs to a Sailpoint Identity IQ Launched Workflow.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
-
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -660,11 +618,6 @@ entities:
     displayName: SailpointLaunchedWorkflowOutput
     externalId: output
     description: Entity representing the outputs to a Sailpoint Identity IQ Launched Workflow.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
-
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -679,15 +632,13 @@ entities:
         type: String
 
   # TODO: Identify unique and index attributes
-  LaunchedWorkflowAttributes:
+  LaunchedWorkflowAttribute:
     parent: LaunchedWorkflows
     displayName: SailpointLaunchedWorkflowAttributes
     externalId: attributes
     description: Entity representing the Sailpoint alert attributes each user is associated with.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
     attributes:
       - name: key
         externalId: key
@@ -734,15 +685,11 @@ entities:
         type: String
 
   # TODO: Identify unique and index attributes
-  ObjectConfigAttributes:
+  ObjectConfigAttribute:
     parent: ObjectConfigs
     displayName: SailpointObjectConfigAttributes
     externalId: objectAttributes
     description: Entity representing the attributes associated with a Sailpoint Identity IQ ObjectConfig.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -784,15 +731,11 @@ entities:
         type: String
 
   # TODO: Identify unique and index attributes
-  ObjectAttributeSources:
+  ObjectAttributeSource:
     parent: objectAttributes
     displayName: SailpointObjectAttributeSources
     externalId: attributeSources
     description: Entity representing the attribute sources associated with a Sailpoint Identity IQ ObjectConfig.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -810,15 +753,11 @@ entities:
         type: String
 
   # TODO: Identify unique and index attributes
-  ObjectAttributeTargets:
+  ObjectAttributeTarget:
     parent: objectAttributes
     displayName: SailpointObjectAttributeTargets
     externalId: attributeTargets
     description: Entity representing the attribute targets associated with a Sailpoint Identity IQ ObjectConfig.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -861,22 +800,22 @@ entities:
         externalId: constraintName
         type: String
       - name: identityValue
-        externalId: identity.value
+        externalId: $.identity.value
         type: String
       - name: identityRef
-        externalId: identity..["$ref"]
+        externalId: $.identity..["$ref"]
         type: String
       - name: identityDisplayName
-        externalId: identity.displayName
+        externalId: $.identity.displayName
         type: String
       - name: ownerValue
-        externalId: owner.value
+        externalId: $.owner.value
         type: String
       - name: ownerRef
-        externalId: owner.["$ref"]
+        externalId: $.owner..["$ref"]
         type: String
       - name: ownerDisplayName
-        externalId: owner.displayName
+        externalId: $.owner.displayName
         type: String
       - name: description
         externalId: description
@@ -902,7 +841,7 @@ entities:
         externalId: $.meta.location
         type: String
 
-  Roles:
+  Role:
     displayName: SailpointRole
     externalId: Roles
     description: Entity representing a Sailpoint Identity IQ Role.
@@ -910,7 +849,6 @@ entities:
     syncMinInterval: 1
     apiCallFrequency: SECONDLY
     apiCallMinInterval: 1
-
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -923,28 +861,28 @@ entities:
         externalId: name
         type: String
       - name: typeIIQ
-        externalId: type.iiq
+        externalId: $.type.iiq
         type: Bool
       - name: typeRequirements
-        externalId: type.requirements
+        externalId: $.type.requirements
         type: Bool
       - name: typePermits
-        externalId: type.permits
+        externalId: $.type.permits
         type: Bool
       - name: typeDisplayName
-        externalId: type.displayName
+        externalId: $.type.displayName
         type: String
       - name: typeManualAssignment
-        externalId: type.manualAssignment
+        externalId: $.type.manualAssignment
         type: Bool
       - name: typeName
-        externalId: type.name
+        externalId: $.type.name
         type: String
       - name: typeAutoAssignment
-        externalId: type.autoAssignment
+        externalId: $.type.autoAssignment
         type: Bool
       - name: typeAssignmentSelector
-        externalId: type.assignmentSelector
+        externalId: $.type.assignmentSelector
         type: Bool
       - name: displayableName
         externalId: displayableName
@@ -959,13 +897,13 @@ entities:
         externalId: deactivationDate
         type: DateTime
       - name: ownerDisplayName
-        externalId: owner.displayName
+        externalId: $.owner.displayName
         type: String
       - name: ownerValue
-        externalId: owner.value
+        externalId: $.owner.value
         type: String
       - name: ownerRef
-        externalId: owner.["$ref"]
+        externalId: $.owner..$.["$ref"]
         type: String
 
       # Meta
@@ -985,15 +923,11 @@ entities:
         externalId: $.meta.location
         type: String
 
-  RoleLocalizedDescriptions:
+  RoleLocalizedDescription:
     parent: Roles
     displayName: SailpointEntitlementLocalizedDescriptions
     externalId: descriptions
     description: Entity representing the localized descriptions associated with a Sailpoint Identity IQ Role.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1009,9 +943,6 @@ entities:
     displayName: SailpointRoleInheritance
     externalId: inheritance
     description: Entity representing the inheritance associated with a Sailpoint Identity IQ Role.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1028,14 +959,11 @@ entities:
         type: String
 
   # TODO: Identify unique and index attributes
-  RoleRequirements:
+  RoleRequirement:
     parent: Roles
     displayName: SailpointRoleRequirements
     externalId: requirements
     description: Entity representing the requirements associated with a Sailpoint Identity IQ Role.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1050,14 +978,11 @@ entities:
         type: String
 
   # TODO: Identify unique and index attributes
-  RolePermits:
+  RolePermit:
     parent: Roles
     displayName: SailpointRolePermits
     externalId: permits
     description: Entity representing the permits associated with a Sailpoint Identity IQ Role.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1072,14 +997,11 @@ entities:
         type: String
 
   # TODO: Identify unique and index attributes
-  RoleClassfications:
+  RoleClassfication:
     parent: Roles
     displayName: SailpointRoleClassfications
     externalId: classifications
     description: Entity representing the classifications associated with a Sailpoint Identity IQ Role.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1090,16 +1012,16 @@ entities:
         externalId: effective
         type: Bool
       - name: classificationName
-        externalId: classification.name
+        externalId: $.classification.name
         type: String
       - name: classificationDisplayName
-        externalId: classification.displayName
+        externalId: $.classification.displayName
         type: String
       - name: classificationOrigin
-        externalId: classification.origin
+        externalId: $.classification.origin
         type: String
       - name: classificationType
-        externalId: classification.type
+        externalId: $.classification.type
         type: String
 
   # TODO: Skip ingestion of this entity?
@@ -1112,36 +1034,38 @@ entities:
     syncMinInterval: 1
     apiCallFrequency: SECONDLY
     apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
     attributes:
       - name: documentationUri
         externalId: documentationUri
         type: String
       - name: patchSupported
-        externalId: patch.supported
+        externalId: $.patch.supported
         type: Bool
       - name: etagSupported
-        externalId: etag.supported
+        externalId: $.etag.supported
         type: Bool
       - name: bulkSupported
-        externalId: bulk.supported
+        externalId: $.bulk.supported
         type: Bool
       - name: bulkMaxOperations
-        externalId: bulk.maxOperations
+        externalId: $.bulk.maxOperations
         type: Int64
       - name: bulkMaxPayloadSize
-        externalId: bulk.maxPayloadSize
+        externalId: $.bulk.maxPayloadSize
         type: Int64
       - name: filterSupported
-        externalId: filter.supported
+        externalId: $.filter.supported
         type: Bool
       - name: filterMaxResults
-        externalId: filter.maxResults
+        externalId: $.filter.maxResults
         type: Int64
       - name: changePasswordSupported
-        externalId: changePassword.supported
-        type: Bool
+        externalId: $.changePassword.supported
+        type: Bool$.
       - name: sortSupported
-        externalId: sort.supported
+        externalId: $.sort.supported
         type: Bool
 
   # TODO: Identify unique and index attributes
@@ -1150,10 +1074,8 @@ entities:
     displayName: SailpointServiceProviderConfigAuthenticationScheme
     externalId: authenticationSchemes
     description: Entity representing the authentication schemes associated with a Sailpoint Identity IQ Service Provider Configuration.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
     attributes:
       - name: name
         externalId: name
@@ -1171,13 +1093,15 @@ entities:
         externalId: type
         type: String
 
-  TaskResults:
+  TaskResult:
     displayName: SailpointTaskResult
     externalId: TaskResults
     description: Entity representing a Sailpoint Identity IQ Task Results.
     syncFrequency: HOURLY
     syncMinInterval: 1
     apiCallFrequency: SECONDLY
+    pageSize: 100
+    pagesOrderedById: false
     attributes:
       - name: id
         externalId: id
@@ -1260,14 +1184,13 @@ entities:
         type: String
 
   # TODO: Identify unique and index attributes
-  TaskResultsAttributes:
+  TaskResultsAttribute:
     parent: TaskResults
     displayName: SailpointTaskResultAttributes
     externalId: attributes
     description: Entity representing the attributes associated with a Sailpoint Identity IQ Task Results.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
+    pageSize: 100
+    pagesOrderedById: false
     attributes:
       - name: key
         externalId: key
@@ -1283,7 +1206,6 @@ entities:
     syncFrequency: HOURLY
     syncMinInterval: 1
     apiCallFrequency: SECONDLY
-
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1296,13 +1218,13 @@ entities:
         externalId: userName
         type: String
       - name: formattedName
-        externalId: name.formatted
+        externalId: $.name.formatted
         type: String
       - name: familyName
-        externalId: name.familyName
+        externalId: $.name.familyName
         type: String
       - name: givenName
-        externalId: name.givenName
+        externalId: $.name.givenName
         type: String
       - name: displayName
         externalId: displayName
@@ -1323,7 +1245,7 @@ entities:
         externalId: $..["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"].manager.displayName
         type: String
       - name: managerRef
-        externalId: $..["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"].manager.["$ref"]
+        externalId: $..["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"].manager..["$ref"]
         type: String
 
       # Sailpoint user extension
@@ -1341,7 +1263,7 @@ entities:
         externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].administrator.value
         type: String
       - name: administratorRef
-        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].administrator.["$ref"]
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].administrator..["$ref"]
         type: String
       - name: administratorDisplayName
         externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].administrator.displayName
@@ -1365,7 +1287,7 @@ entities:
         externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].regionOwner.value
         type: String
       - name: regionOwnerRef
-        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].regionOwner.["$ref"]
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].regionOwner..["$ref"]
         type: String
       - name: location
         externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].location
@@ -1377,7 +1299,7 @@ entities:
         externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].locationOwner.value
         type: String
       - name: locationOwnerRef
-        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].locationOwner.["$ref"]
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].locationOwner..["$ref"]
         type: String
       - name: department
         externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].department
@@ -1415,10 +1337,6 @@ entities:
     displayName: SailpointUserEmail
     externalId: emails
     description: Entity representing the email addresses associated with a Sailpoint Identity IQ User.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1442,9 +1360,6 @@ entities:
     displayName: SailpointUserAccount
     externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].accounts
     description: Entity representing the account associated with a Sailpoint Identity IQ User.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1460,14 +1375,11 @@ entities:
         externalId: $..["$ref"]
         type: String
 
-  SailpointUserEntitlements:
+  SailpointUserEntitlement:
     parent: Users
     displayName: SailpointUserEntitlements
     externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].entitlements
     description: Entity representing the entitlements associated with a Sailpoint Identity IQ User.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1492,14 +1404,11 @@ entities:
         externalId: $..["$ref"]
         type: String
 
-  SailpointUserRoles:
+  SailpointUserRole:
     parent: Users
     displayName: SailpointUserRoles
     externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].roles
     description: Entity representing the roles associated with a Sailpoint Identity IQ User.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1535,7 +1444,6 @@ entities:
     syncMinInterval: 1
     apiCallFrequency: SECONDLY
     apiCallMinInterval: 1
-
     pageSize: 100
     pagesOrderedById: false
     attributes:

--- a/sailpoint.sgnl.yaml
+++ b/sailpoint.sgnl.yaml
@@ -1,0 +1,1576 @@
+# Sailpoint 2.0 Configuration YAML for DS2.0
+# Note: The externalId for each entity must match the endpoint for this resource i.e. 
+# - External ID for an User entity representing a User resource (/Users) is "Users"
+# - External ID for a Group entity representing a Group resource (/Groups) is "Groups"
+
+displayName: "SailPoint"
+icon: PHN2ZyB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTQwLjQxMTggNDIuMTM3M0gxMEwzNS4yMzUzIDEwTDQwLjQxMTggNDIuMTM3M1oiIGZpbGw9IiMwMDMzQTEiLz4KPHBhdGggZD0iTTQwLjQxMTggNDIuMTM3M0g1NEwzNS4yMzUzIDEwTDQwLjQxMTggNDIuMTM3M1oiIGZpbGw9IiNDQzI3QjAiLz4KPHBhdGggZD0iTTQwLjQxMTggNDIuMTM3M0gxMEw0Mi4zNTI5IDUzLjc4NDNMNDAuNDExOCA0Mi4xMzczWiIgZmlsbD0iIzAwNzFDRSIvPgo8cGF0aCBkPSJNNDAuNDExOCA0Mi4xMzczSDU0TDQyLjM1MjkgNTMuNzg0M0w0MC40MTE4IDQyLjEzNzNaIiBmaWxsPSIjRTE3RkQyIi8+Cjwvc3ZnPgo=
+description: "Sailpoint as a System of Record"
+address: "{{Input Required: Sailpoint URL}}"
+defaultSyncFrequency: HOURLY
+defaultSyncMinInterval: 1
+defaultApiCallFrequency: SECONDLY
+defaultApiCallMinInterval: 1
+type: "Sailpoint2.0-1.0.0"
+# Example Configs:
+# empty config: {} | b64: "e30="
+# config with filtering on Users: {"Users":{"queryParams":{"filter":"displayName eq \"SGNL\""}}} | b64: "eyJVc2VycyI6eyJxdWVyeVBhcmFtcyI6eyJmaWx0ZXIiOiJkaXNwbGF5TmFtZSBlcSBcIlNHTkxcIiJ9fQ=="
+# config with filter, ordering and sortBy on Groups {"Groups":{"queryParams":{"filter":"displayName eq \"SGNL\"","sortBy":"userName","ascending":true}}} | b64: "eyJHcm91cHMiOnsicXVlcnlQYXJhbXMiOnsiZmlsdGVyIjoiZGlzcGxheU5hbWUgZXEgXCJTR05MXCIiLCJzb3J0QnkiOiJ1c2VyTmFtZSIsImFzY2VuZGluZyI6dHJ1ZX19fQ=="
+adapterConfig: "e30=" # {}
+# This must match the list of supportedAuthMechanisms specified on the Adapter.
+auth:
+  - basic:
+      username: "{{Input Required: Username}}"
+      password: "{{Input Required: API Token}}"
+entities:
+  Account:
+    displayName: SailpointAccount
+    externalId: Accounts
+    description: Entity representing a Sailpoint Identity IQ Account.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: id
+        externalId: id
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: nativeIdentity
+        externalId: nativeIdentity
+        type: String
+      - name: displayName
+        externalId: displayName
+        type: String
+      - name: instance
+        externalId: instance
+        type: String
+      - name: uuid
+        externalId: uuid
+        type: String
+      - name: active
+        externalId: active
+        type: Bool
+      - name: locked
+        externalId: locked
+        type: Bool
+      - name: lastRefresh
+        externalId: lastRefresh
+        type: DateTime
+      - name: lastTargetAggregation
+        externalId: lastTargetAggregation
+        type: DateTime
+      - name: manuallyCorrelated
+        externalId: manuallyCorrelated
+        type: Bool
+      - name: hasEntitlements
+        externalId: hasEntitlements
+        type: Bool
+      - name: identityValue
+        externalId: identity.value
+        type: String
+      - name: identityRef
+        externalId: identity.["$ref"]
+        type: String
+      - name: identityUserName
+        externalId: identity.userName
+        type: String
+      - name: identityDisplayName
+        externalId: identity.displayName
+        type: String
+      - name: applicationValue
+        externalId: application.value
+        type: String
+      - name: applicationRef
+        externalId: application.["$ref"]
+        type: String
+      - name: applicationDisplayName
+        externalId: application.displayName
+        type: String
+      
+      # Meta
+      - name: resourceType
+        externalId: $.meta.resourceType
+        type: String
+      - name: created
+        externalId: $.meta.created
+        type: DateTime
+      - name: lastModified
+        externalId: $.meta.lastModified
+        type: DateTime
+      - name: version 
+        externalId: $.meta.version
+        type: String  
+      - name: location
+        externalId: $.meta.location
+        type: String
+
+  Alert:
+    displayName: SailpointAlert
+    externalId: Alerts
+    description: Entity representing a Sailpoint Identity IQ Alert.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    attributes:
+      - name: id
+        externalId: id
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: name
+        externalId: name
+        type: String
+      - name: displayName
+        externalId: displayName
+        type: String
+      - name: type
+        externalId: type
+        type: String
+      - name: applicationValue
+        externalId: application.value
+        type: String
+      - name: applicationRef
+        externalId: application.["$ref"]
+        type: String
+      - name: applicationDisplayName
+        externalId: application.displayName
+        type: String
+      - name: alertDate
+        externalId: alertDate
+        type: DateTime
+      - name: lastProcessed
+        externalId: lastProcessed
+        type: DateTime
+      - name: nativeId
+        externalId: nativeId
+        type: String
+      - name: targetId
+        externalId: targetId
+        type: String
+      - name: targetType
+        externalId: targetType
+        type: String
+      - name: targetDisplayName
+        externalId: targetDisplayName
+        type: String
+      
+      # Meta
+      - name: resourceType
+        externalId: $.meta.resourceType
+        type: String
+      - name: created
+        externalId: $.meta.created
+        type: DateTime
+      - name: lastModified
+        externalId: $.meta.lastModified
+        type: DateTime
+      - name: version 
+        externalId: $.meta.version
+        type: String  
+      - name: location
+        externalId: $.meta.location
+        type: String
+  
+  # TODO: Identify unique and index attributes
+  AlertAttributes:
+    parent: Alert
+    displayName: SailpointAlertAttributes
+    externalId: attributes
+    description: Entity representing the attibutes associated with the Sailpoint Identity IQ Alert.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    attributes:
+      - name: key
+        externalId: key
+        type: String
+      - name: value
+        externalId: value
+        type: String
+  
+  AlertActions:
+    parent: Alert
+    displayName: SailpointAlertActions
+    externalId: actions
+    description: Entity representing the actions associated with the Sailpoint Identity IQ Alert.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    attributes:
+      - name: type
+        externalId: type
+        type: String
+      - name: alertDefinitionName
+        externalId: alertDefinitionName
+        type: String
+      - name: resultId
+        externalId: result.id
+        type: String
+        indexed: true
+        uniqueId: true
+
+  AlertActionResult:
+    parent: actions 
+    displayName: SailpointAlertActionResultNotifications
+    externalId: result
+    description: Entity representing the result associated with the Sailpoint Identity IQ Alert Action.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    attributes:
+      - name: name
+        externalId: name
+        type: String
+      - name: workflowName
+        externalId: workflowName
+        type: String
+        indexed: true
+        uniqueId: true
+
+  AlertActionResultNotifications:
+    parent: result 
+    displayName: SailpointAlertActionResultNotifications
+    externalId: notifications
+    description: Entity representing the notifications associated with the Sailpoint Identity IQ Alert Action Result.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    attributes:
+      - name: name
+        externalId: name
+        type: String
+      - name: displayName
+        externalId: displayName
+        type: String
+      - name: emailAddresses
+        externalId: emailAddresses
+        type: String
+        indexed: true
+        uniqueId: true
+
+  Applications:
+    displayName: SailpointApplication
+    externalId: Applications
+    description: Entity representing a Sailpoint Identity IQ Application.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: id
+        externalId: id
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: name
+        externalId: name
+        type: String
+      - name: type
+        externalId: type
+        type: String
+      - name: features
+        externalId: features
+        type: String
+      - name: ownerValue
+        externalId: owner.value
+        type: String
+      - name: ownerRef
+        externalId: owner.["$ref"]
+        type: String
+      - name: ownerDisplayName
+        externalId: owner.displayName
+        type: String
+      
+      # Meta
+      - name: resourceType
+        externalId: $.meta.resourceType
+        type: String
+      - name: created
+        externalId: $.meta.created
+        type: DateTime
+      - name: lastModified
+        externalId: $.meta.lastModified
+        type: DateTime
+      - name: version 
+        externalId: $.meta.version
+        type: String  
+      - name: location
+        externalId: $.meta.location
+        type: String
+
+  ApplicationSchemas:
+    parent: Applications
+    displayName: SailpointApplicationSchemas
+    externalId: applicationSchemas
+    description: Entity representing the schema associated with a Sailpoint Identity IQ Application.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: value
+        externalId: value
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: type
+        externalId: type
+        type: String
+      - name: ref
+        externalId: $..["$ref"]
+        type: String
+
+  ApplicationLocalizedDescriptions:
+    parent: Applications
+    displayName: SailpointApplicationLocalizedDescriptions
+    externalId: descriptions
+    description: Entity representing the localized descriptions associated with a Sailpoint Identity IQ Application.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes: 
+      - name: locale
+        externalId: locale
+        type: String
+      - name: value
+        externalId: value
+        type: String
+        indexed: true
+        uniqueId: true
+
+  Entitlement:
+    displayName: SailpointEntitlement
+    externalId: Entitlements
+    description: Entity representing a Sailpoint Identity IQ Entitlement.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: id
+        externalId: id
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: displayName
+        externalId: displayName
+        type: String
+      - name: type
+        externalId: type
+        type: String
+      - name: requestable
+        externalId: requestable
+        type: Bool
+      - name: aggregated
+        externalId: aggregated
+        type: Bool
+      - name: attribute
+        externalId: attribute
+        type: String
+      - name: value
+        externalId: value
+        type: String
+      - name: lastRefresh
+        externalId: lastRefresh
+        type: DateTime
+      - name: lastTargetAggregation
+        externalId: lastTargetAggregation
+        type: DateTime
+      - name: entitleAuth
+        externalId: entitleAuth
+        type: String
+      - name: entDate
+        externalId: entDate
+        type: DateTime
+      - name: rank
+        externalId: rank
+        type: Int64
+      - name: rule
+        externalId: rule
+        type: String
+      - name: email
+        externalId: email
+        type: String
+      - name: reviewerDisplayName
+        externalId: reviewer.displayName
+        type: String
+      - name: reviewerValue
+        externalId: reviewer.value
+        type: String
+      - name: reviewerRef
+        externalId: reviewer.["$ref"]
+        type: String
+      
+      # Meta
+      - name: resourceType
+        externalId: $.meta.resourceType
+        type: String
+      - name: created
+        externalId: $.meta.created
+        type: DateTime
+      - name: lastModified
+        externalId: $.meta.lastModified
+        type: DateTime
+      - name: version 
+        externalId: $.meta.version
+        type: String  
+      - name: location
+        externalId: $.meta.location
+        type: String
+  
+  # TODO: Identify unique and index attributes
+  EntitlementClassifications:
+    parent: Entitlements
+    displayName: SailpointEntitlementClassifications
+    externalId: classifications
+    description: Entity representing a classification associated with a Sailpoint Identity IQ Entitlement.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes: 
+      - name: source
+        externalId: source
+        type: String
+      - name: effective
+        externalId: effective
+        type: Bool
+      - name: classificationName
+        externalId: classification.name
+        type: String
+      - name: classificationDisplayName
+        externalId: classification.displayName
+        type: String
+      - name: classificationOrigin
+        externalId: classification.origin
+        type: String
+      - name: classificationType
+        externalId: classification.type
+        type: String
+
+  EntitlementLocalizedDescriptions:
+    parent: Entitlements
+    displayName: SailpointEntitlementLocalizedDescriptions
+    externalId: descriptions
+    description: Entity representing the localized descriptions associated with a Sailpoint Identity IQ Entitlement.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes: 
+      - name: locale
+        externalId: locale
+        type: String
+      - name: value
+        externalId: value
+        type: String
+        indexed: true
+        uniqueId: true
+
+  EntitlementApplication:
+    parent: Entitlements
+    displayName: SailpointEntitlementApplications
+    externalId: application
+    description: Entity representing the application associated with a Sailpoint Identity IQ Entitlement.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: value
+        externalId: value
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: displayName
+        externalId: displayName
+        type: String
+      - name: ref
+        externalId: $..["$ref"]
+        type: String
+        
+  EntitlementOwner:
+    parent: Entitlements
+    displayName: SailpointEntitlementOwner
+    externalId: owner
+    description: Entity representing the owner associated with a Sailpoint Identity IQ Entitlement.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes: 
+      - name: value
+        externalId: value
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: displayName
+        externalId: displayName
+        type: String
+      - name: ref
+        externalId: $..["$ref"]
+        type: String
+
+  LaunchedWorkflow:
+    displayName: SailpointLaunchedWorkflow
+    externalId: LaunchedWorkflows
+    description: Entity representing a Sailpoint Identity IQ Launched Workflow.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+
+    attributes:
+      - name: partitioned
+        externalId: partitioned
+        type: Bool
+      - name: completed
+        externalId: completed
+        type: DateTime
+      - name: type
+        externalId: type
+        type: String
+      - name: launched
+        externalId: launched
+        type: DateTime
+      - name: pendingSignOffs
+        externalId: pendingSignOffs
+        type: Int64
+      - name: workflowName
+        externalId: workflowName
+        type: String
+      - name: identityRequestId
+        externalId: identityRequestId
+        type: String
+      - name: workflowCaseId
+        externalId: workflowCaseId
+        type: String
+      - name: workflowProcessId
+        externalId: workflowProcessId
+        type: String
+      - name: retries
+        externalId: retries
+        type: Int64
+      - name: approvalSet
+        externalId: approvalSet
+        type: String
+      - name: workflowSummary
+        externalId: workflowSummary
+        type: String
+      - name: targetClass
+        externalId: targetClass
+        type: String
+      - name: name
+        externalId: name
+        type: String
+      - name: messages
+        externalId: $.messages[*].[*] # Flatten a [][]string to a []string
+        type: String
+        list: true
+      - name: id
+        externalId: id
+        type: String
+        uniqueId: true
+        indexed: true
+      - name: completionStatus
+        externalId: completionStatus
+        type: String
+      - name: taskDefinition
+        externalId: taskDefinition
+        type: String
+      - name: terminated
+        externalId: terminated
+        type: Bool
+      - name: launcher
+        externalId: launcher
+        type: String
+      
+      # Meta
+      - name: resourceType
+        externalId: $.meta.resourceType
+        type: String
+      - name: created
+        externalId: $.meta.created
+        type: DateTime
+      - name: lastModified
+        externalId: $.meta.lastModified
+        type: DateTime
+      - name: version 
+        externalId: $.meta.version
+        type: String  
+      - name: location
+        externalId: $.meta.location
+        type: String
+      
+  # TODO: Identify unique and index attributes
+  LaunchedWorkflowInput:
+    parent: LaunchedWorkflows
+    displayName: SailpointLaunchedWorkflowInput
+    externalId: input
+    description: Entity representing the inputs to a Sailpoint Identity IQ Launched Workflow.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: key
+        externalId: key
+        type: String
+      - name: value
+        externalId: value
+        type: String
+      - name: type
+        externalId: type
+        type: String
+  
+  # TODO: Identify unique and index attributes
+  LaunchedWorkflowOutput:
+    parent: LaunchedWorkflows
+    displayName: SailpointLaunchedWorkflowOutput
+    externalId: output
+    description:  Entity representing the outputs to a Sailpoint Identity IQ Launched Workflow.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: key
+        externalId: key
+        type: String
+      - name: value
+        externalId: value
+        type: String
+      - name: type
+        externalId: type
+        type: String
+  
+  # TODO: Identify unique and index attributes
+  LaunchedWorkflowAttributes:
+    parent: LaunchedWorkflows
+    displayName: SailpointLaunchedWorkflowAttributes
+    externalId: attributes
+    description: Entity representing the Sailpoint alert attributes each user is associated with.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    attributes:
+      - name: key
+        externalId: key
+        type: String
+      - name: value
+        externalId: value
+        type: String
+
+  ObjectConfig:
+    displayName: SailpointObjectConfig
+    externalId: ObjectConfigs
+    description: Entity representing a Sailpoint Identity IQ ObjectConfig.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: id
+        externalId: id
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: name
+        externalId: name
+        type: String
+        
+      # Meta
+      - name: resourceType
+        externalId: $.meta.resourceType
+        type: String
+      - name: created
+        externalId: $.meta.created
+        type: DateTime
+      - name: lastModified
+        externalId: $.meta.lastModified
+        type: DateTime
+      - name: version 
+        externalId: $.meta.version
+        type: String  
+      - name: location
+        externalId: $.meta.location
+        type: String
+  
+  # TODO: Identify unique and index attributes
+  ObjectConfigAttributes:
+    parent: ObjectConfigs
+    displayName: SailpointObjectConfigAttributes
+    externalId: objectAttributes
+    description: Entity representing the attributes associated with a Sailpoint Identity IQ ObjectConfig.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: name
+        externalId: name
+        type: String
+      - name: displayName
+        externalId: displayName
+        type: String
+      - name: type
+        externalId: type
+        type: String
+      - name: multi
+        externalId: multi
+        type: Bool
+      - name: defaultValue
+        externalId: defaultValue
+        type: String
+      - name: system
+        externalId: system
+        type: Bool
+      - name: standard
+        externalId: standard
+        type: Bool
+      - name: extendedNumber
+        externalId: extendedNumber
+        type: Int64
+      - name: namedColumn
+        externalId: namedColumn
+        type: Bool
+      - name: ruleName
+        externalId: ruleName
+        type: String
+      - name: groupFactory
+        externalId: groupFactory
+        type: Bool
+      - name: editMode
+        externalId: editMode
+        type: String
+  
+  # TODO: Identify unique and index attributes
+  ObjectAttributeSources:
+    parent: objectAttributes
+    displayName: SailpointObjectAttributeSources
+    externalId: attributeSources
+    description: Entity representing the attribute sources associated with a Sailpoint Identity IQ ObjectConfig.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: instance
+        externalId: instance
+        type: String
+      - name: name
+        externalId: name
+        type: String
+      - name: ruleName
+        externalId: ruleName
+        type: String
+      - name: key
+        externalId: key
+        type: String
+
+  # TODO: Identify unique and index attributes
+  ObjectAttributeTargets:
+    parent : objectAttributes 
+    displayName: SailpointObjectAttributeTargets
+    externalId: attributeTargets
+    description: Entity representing the attribute targets associated with a Sailpoint Identity IQ ObjectConfig.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: instance
+        externalId: instance
+        type: String
+      - name: name
+        externalId: name
+        type: String
+      - name: ruleName
+        externalId: ruleName
+        type: String
+      - name: key
+        externalId: key
+        type: String
+      - name: provisionAllAccounts
+        externalId: provisionAllAccounts
+        type: Bool
+
+  PolicyViolation:
+    displayName: SailpointPolicyViolation
+    externalId: PolicyViolations
+    description: Entity representing a Sailpoint Identity IQ Policy Violation.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: id
+        externalId: id
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: policyName
+        externalId: policyName
+        type: String
+      - name: constraintName
+        externalId: constraintName
+        type: String
+      - name: identityValue
+        externalId: identity.value
+        type: String
+      - name: identityRef
+        externalId: identity..["$ref"]
+        type: String
+      - name: identityDisplayName
+        externalId: identity.displayName
+        type: String   
+      - name: ownerValue
+        externalId: owner.value
+        type: String
+      - name: ownerRef
+        externalId: owner.["$ref"]
+        type: String
+      - name: ownerDisplayName
+        externalId: owner.displayName
+        type: String
+      - name: description
+        externalId: description
+        type: String
+      - name: status
+        externalId: status
+        type: String
+        
+      # Meta
+      - name: resourceType
+        externalId: $.meta.resourceType
+        type: String
+      - name: created
+        externalId: $.meta.created
+        type: DateTime
+      - name: lastModified
+        externalId: $.meta.lastModified
+        type: DateTime
+      - name: version 
+        externalId: $.meta.version
+        type: String  
+      - name: location
+        externalId: $.meta.location
+        type: String
+
+  Roles:
+    displayName: SailpointRole
+    externalId: Roles
+    description: Entity representing a Sailpoint Identity IQ Role.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: id
+        externalId: id
+        type: String
+        uniqueId: true
+        indexed: true
+      - name: name
+        externalId: name
+        type: String
+      - name: typeIIQ
+        externalId: type.iiq
+        type: Bool
+      - name: typeRequirements
+        externalId: type.requirements
+        type: Bool
+      - name: typePermits
+        externalId: type.permits
+        type: Bool
+      - name: typeDisplayName
+        externalId: type.displayName
+        type: String
+      - name: typeManualAssignment
+        externalId: type.manualAssignment
+        type: Bool
+      - name: typeName
+        externalId: type.name
+        type: String
+      - name: typeAutoAssignment
+        externalId: type.autoAssignment
+        type: Bool 
+      - name: typeAssignmentSelector
+        externalId: type.assignmentSelector
+        type: Bool
+      - name: displayableName
+        externalId: displayableName
+        type: String
+      - name: active
+        externalId: active
+        type: Bool
+      - name: activationDate
+        externalId: activationDate
+        type: DateTime
+      - name: deactivationDate
+        externalId: deactivationDate
+        type: DateTime
+      - name: ownerDisplayName
+        externalId: owner.displayName
+        type: String
+      - name: ownerValue
+        externalId: owner.value
+        type: String  
+      - name: ownerRef
+        externalId: owner.["$ref"]
+        type: String
+        
+      # Meta
+      - name: resourceType
+        externalId: $.meta.resourceType
+        type: String
+      - name: created
+        externalId: $.meta.created
+        type: DateTime
+      - name: lastModified
+        externalId: $.meta.lastModified
+        type: DateTime
+      - name: version 
+        externalId: $.meta.version
+        type: String  
+      - name: location
+        externalId: $.meta.location
+        type: String
+
+  RoleLocalizedDescriptions:
+    parent: Roles
+    displayName: SailpointEntitlementLocalizedDescriptions
+    externalId: descriptions
+    description: Entity representing the localized descriptions associated with a Sailpoint Identity IQ Role.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: locale
+        externalId: locale
+        type: String
+      - name: value
+        externalId: value
+        type: String
+
+  RoleInheritance:
+    parent: Roles
+    displayName: SailpointRoleInheritance
+    externalId: inheritance
+    description: Entity representing the inheritance associated with a Sailpoint Identity IQ Role.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: value
+        externalId: value
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: displayName
+        externalId: displayName
+        type: String
+      - name: ref
+        externalId: $..["$ref"]
+        type: String
+  
+  # TODO: Identify unique and index attributes
+  RoleRequirements:
+    parent: Roles
+    displayName: SailpointRoleRequirements
+    externalId: requirements
+    description: Entity representing the requirements associated with a Sailpoint Identity IQ Role.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: value
+        externalId: value
+        type: String
+      - name: displayName
+        externalId: displayName
+        type: String
+      - name: ref
+        externalId: $..["$ref"]
+        type: String
+
+  # TODO: Identify unique and index attributes
+  RolePermits:
+    parent: Roles
+    displayName: SailpointRolePermits
+    externalId: permits
+    description: Entity representing the permits associated with a Sailpoint Identity IQ Role.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: value
+        externalId: value
+        type: String
+      - name: displayName
+        externalId: displayName
+        type: String
+      - name: ref
+        externalId: $..["$ref"]
+        type: String
+
+  # TODO: Identify unique and index attributes
+  RoleClassfications:
+    parent: Roles
+    displayName: SailpointRoleClassfications
+    externalId: classifications
+    description: Entity representing the classifications associated with a Sailpoint Identity IQ Role.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: source
+        externalId: source
+        type: String
+      - name: effective
+        externalId: effective
+        type: Bool
+      - name: classificationName
+        externalId: classification.name
+        type: String
+      - name: classificationDisplayName
+        externalId: classification.displayName
+        type: String
+      - name: classificationOrigin
+        externalId: classification.origin
+        type: String
+      - name: classificationType
+        externalId: classification.type
+        type: String
+
+  # TODO: Skip ingestion of this entity?  
+  # TODO: Identify unique and index attributes
+  ServiceProviderConfiguration:
+    displayName: SailpointServiceProviderConfiguration
+    externalId: ServiceProviderConfig
+    description: Entity representing a Sailpoint Identity IQ Service Provider Configuration.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    attributes:
+      - name: documentationUri
+        externalId: documentationUri
+        type: String
+      - name: patchSupported
+        externalId: patch.supported
+        type: Bool
+      - name: etagSupported
+        externalId: etag.supported
+        type: Bool
+      - name: bulkSupported
+        externalId: bulk.supported
+        type: Bool
+      - name: bulkMaxOperations
+        externalId: bulk.maxOperations
+        type: Int64
+      - name: bulkMaxPayloadSize
+        externalId: bulk.maxPayloadSize
+        type: Int64
+      - name: filterSupported
+        externalId: filter.supported
+        type: Bool
+      - name: filterMaxResults
+        externalId: filter.maxResults
+        type: Int64
+      - name: changePasswordSupported
+        externalId: changePassword.supported
+        type: Bool
+      - name: sortSupported 
+        externalId: sort.supported
+        type: Bool
+  
+  # TODO: Identify unique and index attributes
+  ServiceProviderConfigAuthenticationScheme:
+    parent: ServiceProviderConfig
+    displayName: SailpointServiceProviderConfigAuthenticationScheme
+    externalId: authenticationSchemes
+    description: Entity representing the authentication schemes associated with a Sailpoint Identity IQ Service Provider Configuration.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    attributes:
+      - name: name
+        externalId: name
+        type: String
+      - name: description
+        externalId: description
+        type: String
+      - name: specUri 
+        externalId: specUri
+        type: String
+      - name: documentationUri
+        externalId: documentationUri
+        type: String
+      - name: type  
+        externalId: type
+        type: String
+
+  TaskResults:
+    displayName: SailpointTaskResult
+    externalId: TaskResults
+    description: Entity representing a Sailpoint Identity IQ Task Results.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    attributes:
+      - name: id
+        externalId: id
+        type: String
+        uniqueId: true
+        indexed: true
+      - name: name
+        externalId: name
+        type: String
+      - name: type
+        externalId: type
+        type: String
+      - name: completionStatus
+        externalId: completionStatus
+        type: String
+      - name: launcher
+        externalId: launcher
+        type: String
+      - name: host
+        externalId: host
+        type: String
+      - name: progress
+        externalId: progress
+        type: String
+      - name: targetClass
+        externalId: targetClass
+        type: String
+      - name: targetName  
+        externalId: targetName
+        type: String
+      - name: terminated
+        externalId: terminated
+        type: Bool
+      - name: partitioned
+        externalId: partitioned
+        type: Bool
+      - name: launched
+        externalId: launched
+        type: DateTime  
+      - name: completed
+        externalId: completed
+        type: DateTime
+      - name: expiration
+        externalId: expiration
+        type: DateTime  
+      - name: verified
+        externalId: verified
+        type: DateTime
+      - name: percentageComplete
+        externalId: percentageComplete
+        type: Int64
+      - name: pendingSignOffs
+        externalId: pendingSignOffs
+        type: Int64
+      - name: taskDefinition
+        externalId: taskDefinition
+        type: String
+      - name: taskSchedule
+        externalId: taskSchedule
+        type: String
+      - name: messages
+        externalId: $.messages[*].[*]  # Flatten a [][]string to a []string
+        type: String
+      
+      # Meta
+      - name: resourceType
+        externalId: $.meta.resourceType
+        type: String
+      - name: created
+        externalId: $.meta.created
+        type: DateTime
+      - name: lastModified
+        externalId: $.meta.lastModified
+        type: DateTime
+      - name: version 
+        externalId: $.meta.version
+        type: String  
+      - name: location
+        externalId: $.meta.location
+        type: String
+
+  # TODO: Identify unique and index attributes
+  TaskResultsAttributes:
+    parent: TaskResults
+    displayName: SailpointTaskResultAttributes
+    externalId: attributes
+    description: Entity representing the attributes associated with a Sailpoint Identity IQ Task Results.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    attributes:
+      - name: key
+        externalId: key
+        type: String
+      - name: value
+        externalId: value
+        type: String
+
+  User:
+    displayName: SailpointUser
+    externalId: Users
+    description: Entity representing a Sailpoint Identity IQ User.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: id
+        externalId: id
+        type: String
+        uniqueId: true
+        indexed: true
+      - name: userName
+        externalId: userName
+        type: String
+      - name: formattedName
+        externalId: name.formatted
+        type: String
+      - name: familyName
+        externalId: name.familyName
+        type: String  
+      - name: givenName
+        externalId: name.givenName
+        type: String
+      - name: displayName
+        externalId: displayName
+        type: String
+      - name: userType
+        externalId: userType
+        type: String
+      - name: active
+        externalId: active
+        type: Bool
+
+      # Enterprise extension
+      - name: managerId
+        externalId: $..["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"].manager.value
+        type: String  
+        indexed: true
+      - name: managerDisplayName
+        externalId: $..["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"].manager.displayName
+        type: String
+      - name: managerRef
+        externalId: $..["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"].manager.["$ref"]
+        type: String
+      
+      # Sailpoint user extension
+      - name: capabilities
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].capabilities
+        type: String
+        list: true
+      - name: riskScore
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].riskScore
+        type: Int64
+      - name: isManager
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].isManager
+        type: Bool
+      - name: administratorId
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].administrator.value
+        type: String
+      - name: administratorRef
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].administrator.["$ref"]
+        type: String
+      - name: administratorDisplayName
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].administrator.displayName
+        type: String
+      - name: softwareVersion
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].softwareVersion
+        type: String
+      - name: empId
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].empId
+        type: String
+      - name: dn
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].dn
+        type: String
+      - name: region
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].region
+        type: String
+      - name: regionOwnerDisplayName
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].regionOwner.displayName
+        type: String
+      - name: regionOwnerValue
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].regionOwner.value
+        type: String
+      - name: regionOwnerRef
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].regionOwner.["$ref"]
+        type: String
+      - name: location 
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].location
+        type: String
+      - name: locationOwnerDisplayName
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].locationOwner.displayName
+        type: String
+      - name: locationOwnerValue
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].locationOwner.value
+        type: String
+      - name: locationOwnerRef
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].locationOwner.["$ref"]
+        type: String
+      - name: department
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].department
+        type: String
+      - name: costcenter
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].costcenter
+        type: String
+        list: true
+      - name: jobTitle
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].jobTitle
+        type: String
+      - name: lastRefresh
+        externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].lastRefresh
+        type: DateTime
+      
+      # Meta
+      - name: resourceType
+        externalId: $.meta.resourceType
+        type: String
+      - name: created
+        externalId: $.meta.created
+        type: DateTime
+      - name: lastModified
+        externalId: $.meta.lastModified
+        type: DateTime
+      - name: version 
+        externalId: $.meta.version
+        type: String  
+      - name: location
+        externalId: $.meta.location
+        type: String
+
+  SailpointUserEmail:
+    parent: Users
+    displayName: SailpointUserEmail
+    externalId: emails
+    description: Entity representing the email addresses associated with a Sailpoint Identity IQ User.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: value
+        externalId: value
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: display
+        externalId: display
+        type: String
+      - name: type
+        externalId: type
+        type: String
+      - name: primary
+        externalId: primary
+        type: Bool
+
+  SailPointUserAccount:
+    parent: Users
+    displayName: SailpointUserAccount
+    externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].accounts
+    description: Entity representing the account associated with a Sailpoint Identity IQ User.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: value
+        externalId: value
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: displayName
+        externalId: displayName
+        type: String
+      - name: ref
+        externalId: $..["$ref"]
+        type: String
+
+  SailpointUserEntitlements:
+    parent: Users
+    displayName: SailpointUserEntitlements
+    externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].entitlements
+    description: Entity representing the entitlements associated with a Sailpoint Identity IQ User.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: value
+        externalId: value
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: display
+        externalId: display
+        type: String
+      - name: type
+        externalId: type
+        type: String
+      - name: application
+        externalId: application
+        type: String
+      - name: accountName
+        externalId: accountName
+        type: String
+      - name: ref
+        externalId: $..["$ref"]
+        type: String
+
+  SailpointUserRoles:
+    parent: Users
+    displayName: SailpointUserRoles
+    externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].roles
+    description: Entity representing the roles associated with a Sailpoint Identity IQ User.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: value
+        externalId: value
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: display
+        externalId: display
+        type: String
+      - name: type
+        externalId: type
+        type: String
+      - name: acquired
+        externalId: acquired
+        type: String
+      - name: application
+        externalId: application
+        type: String
+      - name: accountName
+        externalId: accountName
+        type: String
+      - name: ref
+        externalId: $..["$ref"]
+        type: String
+
+  Workflow:
+    displayName: SailpointWorkflow
+    externalId: Workflows
+    description: Entity representing a Sailpoint Identity IQ Workflow.
+    syncFrequency: HOURLY
+    syncMinInterval: 1
+    apiCallFrequency: SECONDLY
+    apiCallMinInterval: 1
+
+    pageSize: 100
+    pagesOrderedById: false
+    attributes:
+      - name: id
+        externalId: id
+        type: String
+        indexed: true
+        uniqueId: true
+      - name: name
+        externalId: name
+        type: String
+      - name: description
+        externalId: description
+        type: String
+      - name: type
+        externalId: type
+        type: String
+      - name: handler
+        externalId: handler
+        type: String
+      
+      # Meta
+      - name: resourceType
+        externalId: $.meta.resourceType
+        type: String
+      - name: created
+        externalId: $.meta.created
+        type: DateTime
+      - name: lastModified
+        externalId: $.meta.lastModified
+        type: DateTime
+      - name: version 
+        externalId: $.meta.version
+        type: String  
+      - name: location
+        externalId: $.meta.location
+        type: String
+  

--- a/sailpoint.sgnl.yaml
+++ b/sailpoint.sgnl.yaml
@@ -178,7 +178,6 @@ entities:
         externalId: $.meta.location
         type: String
 
-  # TODO: Identify unique and index attributes
   AlertAttribute:
     parent: Alert
     displayName: SailpointAlertAttributes
@@ -190,6 +189,8 @@ entities:
       - name: key
         externalId: key
         type: String
+        indexed: true
+        uniqueId: true
       - name: value
         externalId: value
         type: String
@@ -593,7 +594,6 @@ entities:
         externalId: $.meta.location
         type: String
 
-  # TODO: Identify unique and index attributes
   LaunchedWorkflowInput:
     parent: LaunchedWorkflows
     displayName: SailpointLaunchedWorkflowInput
@@ -605,6 +605,8 @@ entities:
       - name: key
         externalId: key
         type: String
+        indexed: true
+        uniqueId: true
       - name: value
         externalId: value
         type: String
@@ -612,7 +614,6 @@ entities:
         externalId: type
         type: String
 
-  # TODO: Identify unique and index attributes
   LaunchedWorkflowOutput:
     parent: LaunchedWorkflows
     displayName: SailpointLaunchedWorkflowOutput
@@ -624,6 +625,8 @@ entities:
       - name: key
         externalId: key
         type: String
+        indexed: true
+        uniqueId: true
       - name: value
         externalId: value
         type: String
@@ -631,7 +634,6 @@ entities:
         externalId: type
         type: String
 
-  # TODO: Identify unique and index attributes
   LaunchedWorkflowAttribute:
     parent: LaunchedWorkflows
     displayName: SailpointLaunchedWorkflowAttributes
@@ -643,6 +645,8 @@ entities:
       - name: key
         externalId: key
         type: String
+        indexed: true
+        uniqueId: true
       - name: value
         externalId: value
         type: String
@@ -684,7 +688,6 @@ entities:
         externalId: $.meta.location
         type: String
 
-  # TODO: Identify unique and index attributes
   ObjectConfigAttribute:
     parent: ObjectConfigs
     displayName: SailpointObjectConfigAttributes
@@ -696,6 +699,8 @@ entities:
       - name: name
         externalId: name
         type: String
+        indexed: true
+        uniqueId: true
       - name: displayName
         externalId: displayName
         type: String
@@ -730,7 +735,6 @@ entities:
         externalId: editMode
         type: String
 
-  # TODO: Identify unique and index attributes
   ObjectAttributeSource:
     parent: objectAttributes
     displayName: SailpointObjectAttributeSources
@@ -739,6 +743,11 @@ entities:
     pageSize: 100
     pagesOrderedById: false
     attributes:
+      - name: key
+        externalId: key
+        type: String
+        indexed: true
+        uniqueId: true
       - name: instance
         externalId: instance
         type: String
@@ -748,11 +757,7 @@ entities:
       - name: ruleName
         externalId: ruleName
         type: String
-      - name: key
-        externalId: key
-        type: String
 
-  # TODO: Identify unique and index attributes
   ObjectAttributeTarget:
     parent: objectAttributes
     displayName: SailpointObjectAttributeTargets
@@ -761,6 +766,11 @@ entities:
     pageSize: 100
     pagesOrderedById: false
     attributes:
+      - name: key
+        externalId: key
+        type: String
+        indexed: true
+        uniqueId: true
       - name: instance
         externalId: instance
         type: String
@@ -769,9 +779,6 @@ entities:
         type: String
       - name: ruleName
         externalId: ruleName
-        type: String
-      - name: key
-        externalId: key
         type: String
       - name: provisionAllAccounts
         externalId: provisionAllAccounts
@@ -958,7 +965,6 @@ entities:
         externalId: $..["$ref"]
         type: String
 
-  # TODO: Identify unique and index attributes
   RoleRequirement:
     parent: Roles
     displayName: SailpointRoleRequirements
@@ -970,6 +976,8 @@ entities:
       - name: value
         externalId: value
         type: String
+        indexed: true
+        uniqueId: true
       - name: displayName
         externalId: displayName
         type: String
@@ -977,7 +985,6 @@ entities:
         externalId: $..["$ref"]
         type: String
 
-  # TODO: Identify unique and index attributes
   RolePermit:
     parent: Roles
     displayName: SailpointRolePermits
@@ -989,6 +996,8 @@ entities:
       - name: value
         externalId: value
         type: String
+        indexed: true
+        uniqueId: true
       - name: displayName
         externalId: displayName
         type: String
@@ -996,7 +1005,6 @@ entities:
         externalId: $..["$ref"]
         type: String
 
-  # TODO: Identify unique and index attributes
   RoleClassfication:
     parent: Roles
     displayName: SailpointRoleClassfications
@@ -1005,15 +1013,11 @@ entities:
     pageSize: 100
     pagesOrderedById: false
     attributes:
-      - name: source
-        externalId: source
-        type: String
-      - name: effective
-        externalId: effective
-        type: Bool
       - name: classificationName
         externalId: $.classification.name
         type: String
+        indexed: true
+        uniqueId: true
       - name: classificationDisplayName
         externalId: $.classification.displayName
         type: String
@@ -1023,76 +1027,13 @@ entities:
       - name: classificationType
         externalId: $.classification.type
         type: String
-
-  # TODO: Skip ingestion of this entity?
-  # TODO: Identify unique and index attributes
-  ServiceProviderConfiguration:
-    displayName: SailpointServiceProviderConfiguration
-    externalId: ServiceProviderConfig
-    description: Entity representing a Sailpoint Identity IQ Service Provider Configuration.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
-    pageSize: 100
-    pagesOrderedById: false
-    attributes:
-      - name: documentationUri
-        externalId: documentationUri
+      - name: source
+        externalId: source
         type: String
-      - name: patchSupported
-        externalId: $.patch.supported
+      - name: effective
+        externalId: effective
         type: Bool
-      - name: etagSupported
-        externalId: $.etag.supported
-        type: Bool
-      - name: bulkSupported
-        externalId: $.bulk.supported
-        type: Bool
-      - name: bulkMaxOperations
-        externalId: $.bulk.maxOperations
-        type: Int64
-      - name: bulkMaxPayloadSize
-        externalId: $.bulk.maxPayloadSize
-        type: Int64
-      - name: filterSupported
-        externalId: $.filter.supported
-        type: Bool
-      - name: filterMaxResults
-        externalId: $.filter.maxResults
-        type: Int64
-      - name: changePasswordSupported
-        externalId: $.changePassword.supported
-        type: Bool$.
-      - name: sortSupported
-        externalId: $.sort.supported
-        type: Bool
-
-  # TODO: Identify unique and index attributes
-  ServiceProviderConfigAuthenticationScheme:
-    parent: ServiceProviderConfig
-    displayName: SailpointServiceProviderConfigAuthenticationScheme
-    externalId: authenticationSchemes
-    description: Entity representing the authentication schemes associated with a Sailpoint Identity IQ Service Provider Configuration.
-    pageSize: 100
-    pagesOrderedById: false
-    attributes:
-      - name: name
-        externalId: name
-        type: String
-      - name: description
-        externalId: description
-        type: String
-      - name: specUri
-        externalId: specUri
-        type: String
-      - name: documentationUri
-        externalId: documentationUri
-        type: String
-      - name: type
-        externalId: type
-        type: String
-
+      
   TaskResult:
     displayName: SailpointTaskResult
     externalId: TaskResults
@@ -1183,7 +1124,6 @@ entities:
         externalId: $.meta.location
         type: String
 
-  # TODO: Identify unique and index attributes
   TaskResultsAttribute:
     parent: TaskResults
     displayName: SailpointTaskResultAttributes
@@ -1195,6 +1135,8 @@ entities:
       - name: key
         externalId: key
         type: String
+        indexed: true
+        uniqueId: true
       - name: value
         externalId: value
         type: String

--- a/sailpoint.sgnl.yaml
+++ b/sailpoint.sgnl.yaml
@@ -78,6 +78,7 @@ entities:
       - name: identityUserName
         externalId: $.identity.userName
         type: String
+        indexed: true
       - name: identityDisplayName
         externalId: $.identity.displayName
         type: String


### PR DESCRIPTION
This PR adds entities and its corresponding attributes for the Sailpoint SoR.
Resources are linked in the [shortcut story](https://app.shortcut.com/sgnl/story/16211).

These resources are not added to the template right now and can be added based on demand.
- [Schemas](https://developer.sailpoint.com/iiq/api/schemas/)
- [Resource Types](https://developer.sailpoint.com/iiq/api/resource-types/)