### PR TITLE
[sc-19213] Index `identityId` attribute on accounts

### DIFF
--- a/identitynow.sgnl.yaml
+++ b/identitynow.sgnl.yaml
@@ -67,6 +67,7 @@ entities:
       - name: identityId
         externalId: identityId
         type: String
+        indexed: true
       - name: authoritative
         externalId: authoritative
         type: Bool


### PR DESCRIPTION
Since we're creating the `AccountIdentity` relationship:
```yaml
  AccountIdentity:
    name: AccountIdentity
    fromAttribute: accounts.identityId
    toAttribute: identities.id
```
we need to also index `accounts.identityId`, otherwise this template fails.