### PR TITLE
[sc-17103] Update legacy SGNL-ai/sgnl adapters to v1.0.1

### DIFF
--- a/azure-ad.sgnl.yaml
+++ b/azure-ad.sgnl.yaml
@@ -11,7 +11,7 @@ defaultApiCallMinInterval: 1
 type: "AzureAD-1.0.1"
 # Example Config:
 # {"requestTimeoutSeconds": 10, "apiVersion": "v1.0"}
-adapterConfig: "eyJyZXF1ZXN0VGltZW91dFNlY29uZHMiOiAxMCwgImFwaVZlcnNpb24iOiAidjIifQ=="
+adapterConfig: "eyJyZXF1ZXN0VGltZW91dFNlY29uZHMiOiAxMCwgImFwaVZlcnNpb24iOiAidjEuMCJ9"
 # All auth mechanisms specified below must be supported by the specified Adapter.
 auth:
   - oAuth2ClientCredentials:

--- a/azure-ad.sgnl.yaml
+++ b/azure-ad.sgnl.yaml
@@ -8,10 +8,10 @@ defaultSyncFrequency: HOURLY
 defaultSyncMinInterval: 1
 defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
-type: "AzureAD-1.0.0"
+type: "AzureAD-1.0.1"
 # Example Config:
-# {"version": 1, "config": {"filters": {}, "requestTimeout": "10s", "azuread": {"apiVersion": "v1.0"}}}
-adapterConfig: "ewoJInZlcnNpb24iOiAxLAoJImNvbmZpZyI6IHsKICAgICAgICAgICAgICAgICJmaWx0ZXJzIjoge30sCgkJInJlcXVlc3RUaW1lb3V0IjogIjEwcyIsCgkJImF6dXJlYWQiOiB7CiAgICAgICAgICAgICAgICAgICAgImFwaVZlcnNpb24iOiAidjEuMCIKICAgICAgICAgICAgICAgIH0KCX0KfQ=="
+# {"requestTimeoutSeconds": 10, "apiVersion": "v2"}
+adapterConfig: "eyJyZXF1ZXN0VGltZW91dFNlY29uZHMiOiAxMCwgImFwaVZlcnNpb24iOiAidjIifQ=="
 # All auth mechanisms specified below must be supported by the specified Adapter.
 auth:
   - oAuth2ClientCredentials:

--- a/azure-ad.sgnl.yaml
+++ b/azure-ad.sgnl.yaml
@@ -10,7 +10,7 @@ defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
 type: "AzureAD-1.0.1"
 # Example Config:
-# {"requestTimeoutSeconds": 10, "apiVersion": "v2"}
+# {"requestTimeoutSeconds": 10, "apiVersion": "v1.0"}
 adapterConfig: "eyJyZXF1ZXN0VGltZW91dFNlY29uZHMiOiAxMCwgImFwaVZlcnNpb24iOiAidjIifQ=="
 # All auth mechanisms specified below must be supported by the specified Adapter.
 auth:

--- a/okta.sgnl.yaml
+++ b/okta.sgnl.yaml
@@ -8,10 +8,10 @@ defaultSyncFrequency: HOURLY
 defaultSyncMinInterval: 1
 defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
-type: "Okta-1.0.0"
+type: "Okta-1.0.1"
 # Example Config:
-# {"version": 1, "config": {"requestTimeout": "10s", "okta": {"apiVersion": "v1"}}}
-adapterConfig: "ewogICAgInZlcnNpb24iOiAxLAogICAgImNvbmZpZyI6IHsKICAgICAgICAicmVxdWVzdFRpbWVvdXQiOiAiMTBzIiwKICAgICAgICAib2t0YSI6IHsKICAgICAgICAgICAgImFwaVZlcnNpb24iOiAidjEiCiAgICAgICAgfQogICAgfQp9"
+# {"requestTimeoutSeconds": 10, "apiVersion": "v1"}
+adapterConfig: "eyJyZXF1ZXN0VGltZW91dFNlY29uZHMiOiAxMCwgImFwaVZlcnNpb24iOiAidjEifQ=="
 # All auth mechanisms specified below must be supported by the specified Adapter.
 auth:
   - oAuth2ClientCredentials:

--- a/salesforce.sgnl.yaml
+++ b/salesforce.sgnl.yaml
@@ -8,10 +8,10 @@ defaultSyncFrequency: HOURLY
 defaultSyncMinInterval: 1
 defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
-type: "Salesforce-1.0.0"
+type: "Salesforce-1.0.1"
 # Example Config:
-# {"version": 1, "config": {"requestTimeout": "10s", "salesforce": {"apiVersion":"56.0"}}}
-adapterConfig: "ewoJInZlcnNpb24iOiAxLAoJImNvbmZpZyI6IHsKCQkicmVxdWVzdFRpbWVvdXQiOiAiMTBzIiwKCQkic2FsZXNmb3JjZSI6IHsiYXBpVmVyc2lvbiI6IjU2LjAifQoJfQp9"
+# {"requestTimeoutSeconds": 10, "apiVersion": "56.0"}
+adapterConfig: "eyJyZXF1ZXN0VGltZW91dFNlY29uZHMiOiAxMCwgImFwaVZlcnNpb24iOiAiNTYuMCJ9"
 # All auth mechanisms specified below must be supported by the specified Adapter.
 auth:
   - oAuth2ClientCredentials:

--- a/salesforce.sgnl.yaml
+++ b/salesforce.sgnl.yaml
@@ -10,8 +10,8 @@ defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
 type: "Salesforce-1.0.1"
 # Example Config:
-# {"requestTimeoutSeconds": 10, "apiVersion": "56.0"}
-adapterConfig: "eyJyZXF1ZXN0VGltZW91dFNlY29uZHMiOiAxMCwgImFwaVZlcnNpb24iOiAiNTYuMCJ9"
+# {"requestTimeoutSeconds": 10, "apiVersion": "58.0"}
+adapterConfig: "eyJyZXF1ZXN0VGltZW91dFNlY29uZHMiOiAxMCwgImFwaVZlcnNpb24iOiAiNTguMCJ9"
 # All auth mechanisms specified below must be supported by the specified Adapter.
 auth:
   - oAuth2ClientCredentials:

--- a/servicenow-csm.sgnl.yaml
+++ b/servicenow-csm.sgnl.yaml
@@ -7,10 +7,10 @@ defaultSyncFrequency: HOURLY
 defaultSyncMinInterval: 1
 defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
-type: "ServiceNow-1.0.0"
+type: "ServiceNow-1.0.1"
 # Example Config:
-# {"version": 1, "config": {"requestTimeout": "10s", "servicenow": {}}}
-adapterConfig: "CnsKCSJ2ZXJzaW9uIjogMSwKCSJjb25maWciOiB7CgkJInJlcXVlc3RUaW1lb3V0IjogIjEwcyIsCgkJInNlcnZpY2Vub3ciOiB7fQoJfQp9Cg=="
+# {"requestTimeoutSeconds": 10, "apiVersion": "v2"}
+adapterConfig: "eyJyZXF1ZXN0VGltZW91dFNlY29uZHMiOiAxMCwgImFwaVZlcnNpb24iOiAidjIifQ=="
 # All auth mechanisms specified below must be supported by the specified Adapter.
 auth:
   - basic:

--- a/servicenow-itsm.sgnl.yaml
+++ b/servicenow-itsm.sgnl.yaml
@@ -7,10 +7,10 @@ defaultSyncFrequency: HOURLY
 defaultSyncMinInterval: 1
 defaultApiCallFrequency: SECONDLY
 defaultApiCallMinInterval: 1
-type: "ServiceNow-1.0.0"
+type: "ServiceNow-1.0.1"
 # Example Config:
-# {"version": 1, "config": {"requestTimeout": "10s", "servicenow": {}}}
-adapterConfig: "CnsKCSJ2ZXJzaW9uIjogMSwKCSJjb25maWciOiB7CgkJInJlcXVlc3RUaW1lb3V0IjogIjEwcyIsCgkJInNlcnZpY2Vub3ciOiB7fQoJfQp9Cg=="
+# {"requestTimeoutSeconds": 10, "apiVersion": "v2"}
+adapterConfig: "eyJyZXF1ZXN0VGltZW91dFNlY29uZHMiOiAxMCwgImFwaVZlcnNpb24iOiAidjIifQ=="
 # All auth mechanisms specified below must be supported by the specified Adapter.
 auth:
   - basic:


### PR DESCRIPTION
- Updates the default version of Okta, Salesforce, Servicenow and AzureAD from 1.0.0 (SGNL-ai/sgnl adapters) to 1.0.1 (SGNL-ai/adapter-sgnl adapters)

Note: I've verified these adapters are created in dev, stg and prod.