### PR TITLE
mj-remove-entity-syncsettings

### DIFF
--- a/azure-ad.sgnl.yaml
+++ b/azure-ad.sgnl.yaml
@@ -28,10 +28,6 @@ entities:
     displayName: User
     externalId: User
     description: User Entity in Azure AD
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 999
     pagesOrderedById: false
     attributes:
@@ -216,10 +212,6 @@ entities:
     description: "Group Entity in Azure AD"
     displayName: Group
     externalId: Group
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 999
     pagesOrderedById: false
     attributes:
@@ -334,10 +326,6 @@ entities:
     description: "Group Member Entity in Azure AD"
     displayName: GroupMember
     externalId: GroupMember
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 999
     pagesOrderedById: false
     attributes:
@@ -359,10 +347,6 @@ entities:
     description: "Application Entity in Azure AD"
     displayName: Application
     externalId: Application
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 999
     pagesOrderedById: false
     attributes:
@@ -506,10 +490,6 @@ entities:
     description: "Device Entity in Azure AD"
     displayName: Device
     externalId: Device
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 999
     pagesOrderedById: false
     attributes:

--- a/curity.sgnl.yaml
+++ b/curity.sgnl.yaml
@@ -30,10 +30,6 @@ entities:
     displayName: User
     externalId: Users
     description: User entity in Curity
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:

--- a/duo.sgnl.yaml
+++ b/duo.sgnl.yaml
@@ -19,10 +19,6 @@ entities:
     displayName: User
     externalId: User
     description: User entity in Duo
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -85,10 +81,6 @@ entities:
     displayName: GroupMember
     externalId: groups
     description: Entity representing the Duo groups each user belongs to
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -106,10 +98,6 @@ entities:
     displayName: PhoneOwner
     externalId: phones
     description: Entity representing the Duo phones owned by the User
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -126,10 +114,6 @@ entities:
     displayName: Group
     externalId: Group
     description: Group entity in Duo
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:

--- a/identitynow.sgnl.yaml
+++ b/identitynow.sgnl.yaml
@@ -43,10 +43,6 @@ entities:
     displayName: Account
     externalId: accounts
     description: Account entity in IdentityNow
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 250
     pagesOrderedById: false
     attributes:
@@ -102,10 +98,6 @@ entities:
     displayName: Entitlement
     externalId: entitlements
     description: Entitlement entity in IdentityNow
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 250
     pagesOrderedById: false
     attributes:
@@ -154,10 +146,6 @@ entities:
     # to create the relationship between Entitlement and Account.
     externalId: accountEntitlements
     description: AccountEntitlement entity in IdentityNow
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 250
     pagesOrderedById: false
     attributes:
@@ -178,10 +166,6 @@ entities:
     displayName: Identity
     externalId: identities
     description: Identity entity in IdentityNow
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 250
     pagesOrderedById: false
     attributes:

--- a/jira.sgnl.yaml
+++ b/jira.sgnl.yaml
@@ -26,10 +26,6 @@ entities:
     displayName: User
     externalId: User
     description: User entity in Jira
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -63,10 +59,6 @@ entities:
     displayName: Issue
     externalId: Issue
     description: Issue entity in Jira
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -343,10 +335,6 @@ entities:
     displayName: Group
     externalId: Group
     description: Group entity in Jira
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -363,10 +351,6 @@ entities:
     displayName: GroupMember
     externalId: GroupMember
     description: Group Member entity in Jira
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -389,10 +373,6 @@ entities:
     displayName: Workspace
     externalId: Workspace
     description: Workspace entity in Jira
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -409,10 +389,6 @@ entities:
     displayName: Object
     externalId: Object
     description: Object entity in Jira
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:

--- a/okta.sgnl.yaml
+++ b/okta.sgnl.yaml
@@ -27,10 +27,6 @@ entities:
     displayName: User
     externalId: User
     description: User entity in Okta
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -165,10 +161,6 @@ entities:
     displayName: Group
     externalId: Group
     description: Group entity in Okta
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -204,10 +196,6 @@ entities:
     displayName: GroupMember
     externalId: GroupMember
     description: Group Member entity in Okta
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:

--- a/pagerduty.sgnl.yaml
+++ b/pagerduty.sgnl.yaml
@@ -30,10 +30,6 @@ entities:
     displayName: User
     externalId: users
     description: User entity in PagerDuty
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -99,10 +95,6 @@ entities:
     displayName: Team
     externalId: teams
     description: Team entity in PagerDuty
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -138,10 +130,6 @@ entities:
     displayName: TeamMember
     externalId: members
     description: TeamMember entity in PagerDuty
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -167,10 +155,6 @@ entities:
     displayName: Incident
     externalId: incidents
     description: Incident entity in PagerDuty
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -335,10 +319,6 @@ entities:
     displayName: Service
     externalId: services
     description: Service entity in PagerDuty
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -462,10 +442,6 @@ entities:
     displayName: Schedule
     externalId: schedules
     description: Schedule entity in PagerDuty
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -513,10 +489,6 @@ entities:
     displayName: OnCall
     externalId: oncalls
     description: OnCall entity in PagerDuty
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:

--- a/sailpoint-iiq.sgnl.yaml
+++ b/sailpoint-iiq.sgnl.yaml
@@ -27,10 +27,6 @@ entities:
     displayName: Account
     externalId: Accounts
     description: Entity representing a Sailpoint Identity IQ Account.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -113,10 +109,6 @@ entities:
     displayName: Alert
     externalId: Alerts
     description: Entity representing a Sailpoint Identity IQ Alert.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -257,10 +249,6 @@ entities:
     displayName: Application
     externalId: Applications
     description: Entity representing a Sailpoint Identity IQ Application.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -347,10 +335,6 @@ entities:
     displayName: Entitlement
     externalId: Entitlements
     description: Entity representing a Sailpoint Identity IQ Entitlement.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -507,10 +491,6 @@ entities:
     displayName: LaunchedWorkflow
     externalId: LaunchedWorkflows
     description: Entity representing a Sailpoint Identity IQ Launched Workflow.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -789,10 +769,6 @@ entities:
     displayName: PolicyViolation
     externalId: PolicyViolations
     description: Entity representing a Sailpoint Identity IQ Policy Violation.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -853,10 +829,6 @@ entities:
     displayName: Role
     externalId: Roles
     description: Entity representing a Sailpoint Identity IQ Role.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1041,9 +1013,6 @@ entities:
     displayName: TaskResult
     externalId: TaskResults
     description: Entity representing a Sailpoint Identity IQ Task Results.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1148,9 +1117,6 @@ entities:
     displayName: User
     externalId: Users
     description: Entity representing a Sailpoint Identity IQ User.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1385,10 +1351,6 @@ entities:
     displayName: Workflow
     externalId: Workflows
     description: Entity representing a Sailpoint Identity IQ Workflow.
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:

--- a/salesforce.sgnl.yaml
+++ b/salesforce.sgnl.yaml
@@ -24,10 +24,6 @@ entities:
     displayName: Account
     externalId: Account
     description: Account entity in Salesforce
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 200 # Current minimum enforced by Salesforce API
     pagesOrderedById: true
     attributes:
@@ -263,10 +259,6 @@ entities:
     displayName: Case
     externalId: Case
     description: Case entity in Salesforce
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 200 # Current minimum enforced by Salesforce API
     pagesOrderedById: true
     attributes:
@@ -422,10 +414,6 @@ entities:
     displayName: Customer
     externalId: Customer
     description: Customer entity in Salesforce
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 200 # Current minimum enforced by Salesforce API
     pagesOrderedById: true
     attributes:
@@ -494,10 +482,6 @@ entities:
     displayName: User
     externalId: User
     description: User entity in Salesforce
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 200 # Current minimum enforced by Salesforce API
     pagesOrderedById: true
     attributes:
@@ -930,10 +914,6 @@ entities:
     displayName: Group
     externalId: Group
     description: Public Group entity in Salesforce
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 200 # Current minimum enforced by Salesforce API
     pagesOrderedById: true
     attributes:

--- a/scim-2.0.sgnl.yaml
+++ b/scim-2.0.sgnl.yaml
@@ -35,10 +35,6 @@ entities:
     displayName: User
     externalId: Users
     description: User entity in SCIM
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -147,10 +143,6 @@ entities:
     displayName: Group
     externalId: Groups
     description: Group entity in SCIM
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -174,10 +166,6 @@ entities:
     displayName: GroupMember
     externalId: groups
     description: Entity representing the SCIM groups each user belongs to
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 100
     pagesOrderedById: false
     attributes:

--- a/servicenow-csm.sgnl.yaml
+++ b/servicenow-csm.sgnl.yaml
@@ -21,10 +21,6 @@ entities:
     displayName: User
     externalId: sys_user
     description: User Entity in ServiceNow
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 350
     pagesOrderedById: true
     attributes:
@@ -235,10 +231,6 @@ entities:
     displayName: Case
     externalId: sn_customerservice_case
     description: Case Entity in ServiceNow
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 350
     pagesOrderedById: true
     attributes:
@@ -622,10 +614,6 @@ entities:
     displayName: Account
     externalId: customer_account
     description: Account Entity in ServiceNow
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 350
     pagesOrderedById: true
     attributes:
@@ -798,10 +786,6 @@ entities:
     displayName: Group
     externalId: sys_user_group
     description: Group Entity in ServiceNow
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 350
     pagesOrderedById: true
     attributes:
@@ -876,10 +860,6 @@ entities:
     displayName: GroupMember
     externalId: sys_user_grmember
     description: GroupMember Entity in ServiceNow
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 350
     pagesOrderedById: true
     attributes:

--- a/servicenow-itsm.sgnl.yaml
+++ b/servicenow-itsm.sgnl.yaml
@@ -21,10 +21,6 @@ entities:
     displayName: User
     externalId: sys_user
     description: User Entity in ServiceNow
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 350
     pagesOrderedById: true
     attributes:
@@ -236,10 +232,6 @@ entities:
     displayName: Group
     externalId: sys_user_group
     description: Group Entity in ServiceNow
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 350
     pagesOrderedById: true
     attributes:
@@ -315,10 +307,6 @@ entities:
     displayName: GroupMember
     externalId: sys_user_grmember
     description: GroupMember Entity in ServiceNow
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 350
     pagesOrderedById: true
     attributes:
@@ -361,10 +349,6 @@ entities:
     displayName: Incident
     externalId: incident
     description: Incident Entity in ServiceNow
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 350
     pagesOrderedById: true
     attributes:
@@ -476,10 +460,6 @@ entities:
     displayName: ChangeRequest
     externalId: change_request
     description: Change Request Entity in ServiceNow
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 350
     pagesOrderedById: true
     attributes:
@@ -555,10 +535,6 @@ entities:
     displayName: ChangeTask
     externalId: change_task
     description: Change Task Entity in ServiceNow
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 350
     pagesOrderedById: true
     attributes:
@@ -601,10 +577,6 @@ entities:
     displayName: Problem
     externalId: problem
     description: Problem Entity in ServiceNow
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 350
     pagesOrderedById: true
     attributes:
@@ -705,10 +677,6 @@ entities:
     displayName: CMDB Business App
     externalId: cmdb_ci_business_app
     description: CMDB Business App Entity in ServiceNow
-    syncFrequency: HOURLY
-    syncMinInterval: 1
-    apiCallFrequency: SECONDLY
-    apiCallMinInterval: 1
     pageSize: 350
     pagesOrderedById: true
     attributes:


### PR DESCRIPTION
Removing the per-entity sync settings that are present on most templates - we should use default settings unless there is a reason to do something different.

ServiceNow cases feels like an obvious exception, but lets pull it all back for now and change on exception going forward for all templates.