### PR TITLE
[sc-28595] Fix display name for RoleMemberOf join relationship

### DIFF
--- a/azure-ad.sgnl.yaml
+++ b/azure-ad.sgnl.yaml
@@ -631,7 +631,7 @@ relationships:
     toAttribute: Role.id
   RoleMemberOf:
     name: MemberOf
-    displayName: Member Of
+    displayName: Role Member Of
     fromAttribute: RoleMember.memberId
     toAttribute: Role.id
   UserMemberRole:


### PR DESCRIPTION
Changed display name for `RoleMemberOf` join relationship from `Member Of` to `Role Member Of`.