### PR TITLE
[sc-34496] Fix AzureAD template.

### DIFF
--- a/azure-ad.sgnl.yaml
+++ b/azure-ad.sgnl.yaml
@@ -567,7 +567,8 @@ entities:
       - name: registeredOwner
         externalId: $.registeredOwners[0].id
         type: String
-        attributeAlias: registeredOwner
+        attributeAlias: deviceRegisteredOwner
+        indexed: true
       - name: systemLabels
         externalId: systemLabels
         type: String

--- a/azure-ad.sgnl.yaml
+++ b/azure-ad.sgnl.yaml
@@ -658,7 +658,7 @@ relationships:
   DeviceOwner:
     name: DeviceOwner
     displayName: Device Owner
-    fromAttribute: registeredOwner
+    fromAttribute: deviceRegisteredOwner
     toAttribute: User.id
   UserManager:
     name: Manager

--- a/azure-ad.sgnl.yaml
+++ b/azure-ad.sgnl.yaml
@@ -567,6 +567,7 @@ entities:
       - name: registeredOwner
         externalId: $.registeredOwners[0].id
         type: String
+        attributeAlias: registeredOwner
       - name: systemLabels
         externalId: systemLabels
         type: String
@@ -656,7 +657,7 @@ relationships:
   DeviceOwner:
     name: DeviceOwner
     displayName: Device Owner
-    fromAttribute: Device.registeredOwner
+    fromAttribute: registeredOwner
     toAttribute: User.id
   UserManager:
     name: Manager


### PR DESCRIPTION
This PR fixes the template by adding an attribute alias for Device.registeredOwner.