### PR TITLE
[sc-42171] Fix typo in UserMemberRole relationship

### DIFF
--- a/entra-id.sgnl.yaml
+++ b/entra-id.sgnl.yaml
@@ -726,7 +726,7 @@ relationships:
     path:
       - relationship: UserRoleMember
         direction: Backward
-      - relationship: RoleMemberOf
+      - relationship: RoleMember
         direction: Forward
   RoleMemberRole:
     name: Role


### PR DESCRIPTION
To create a path relationship between a User and a Role, we need the following join relationships:
A) RoleMember.memberId --> User.id
B) RoleMember.roleId --> Role.id

The path relationship would be:
User --> RoleMember --> Role

Previously, it was using the `RoleMember.memberId --> Role.id` instead of B).

