### PR TITLE
Update sailpoint-iiq.sgnl.yaml

### DIFF
--- a/sailpoint-iiq.sgnl.yaml
+++ b/sailpoint-iiq.sgnl.yaml
@@ -3,9 +3,9 @@
 # - External ID for an User entity representing a User resource (/Users) is "Users"
 # - External ID for a Group entity representing a Group resource (/Groups) is "Groups"
 
-displayName: "Sailpoint (IdentityIQ)"
+displayName: "Sailpoint (ISC)"
 icon: PHN2ZyB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTQwLjQxMTggNDIuMTM3M0gxMEwzNS4yMzUzIDEwTDQwLjQxMTggNDIuMTM3M1oiIGZpbGw9IiMwMDMzQTEiLz4KPHBhdGggZD0iTTQwLjQxMTggNDIuMTM3M0g1NEwzNS4yMzUzIDEwTDQwLjQxMTggNDIuMTM3M1oiIGZpbGw9IiNDQzI3QjAiLz4KPHBhdGggZD0iTTQwLjQxMTggNDIuMTM3M0gxMEw0Mi4zNTI5IDUzLjc4NDNMNDAuNDExOCA0Mi4xMzczWiIgZmlsbD0iIzAwNzFDRSIvPgo8cGF0aCBkPSJNNDAuNDExOCA0Mi4xMzczSDU0TDQyLjM1MjkgNTMuNzg0M0w0MC40MTE4IDQyLjEzNzNaIiBmaWxsPSIjRTE3RkQyIi8+Cjwvc3ZnPgo=
-description: "Sailpoint Identity IQ as a System of Record"
+description: "Sailpoint Identity Security Cloud as a System of Record"
 address: "{{Input Required: Sailpoint URL}}"
 defaultSyncFrequency: HOURLY
 defaultSyncMinInterval: 1
@@ -26,7 +26,7 @@ entities:
   Account:
     displayName: Account
     externalId: Accounts
-    description: Entity representing a Sailpoint Identity IQ Account.
+    description: Entity representing a Sailpoint ISC Account.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -108,7 +108,7 @@ entities:
   Alert:
     displayName: Alert
     externalId: Alerts
-    description: Entity representing a Sailpoint Identity IQ Alert.
+    description: Entity representing a Sailpoint ISC Alert.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -175,7 +175,7 @@ entities:
     parent: Alerts
     displayName: Attributes
     externalId: attributes
-    description: Entity representing the attibutes associated with the Sailpoint Identity IQ Alert.
+    description: Entity representing the attibutes associated with the Sailpoint ISC Alert.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -192,7 +192,7 @@ entities:
     parent: Alerts
     displayName: AlertActions
     externalId: actions
-    description: Entity representing the actions associated with the Sailpoint Identity IQ Alert.
+    description: Entity representing the actions associated with the Sailpoint ISC Alert.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -212,7 +212,7 @@ entities:
     parent: actions
     displayName: AlertActionResultNotifications
     externalId: result
-    description: Entity representing the result associated with the Sailpoint Identity IQ Alert Action.
+    description: Entity representing the result associated with the Sailpoint ISC Alert Action.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -229,7 +229,7 @@ entities:
     parent: result
     displayName: AlertActionResultNotifications
     externalId: notifications
-    description: Entity representing the notifications associated with the Sailpoint Identity IQ Alert Action Result.
+    description: Entity representing the notifications associated with the Sailpoint ISC Alert Action Result.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -248,7 +248,7 @@ entities:
   Applications:
     displayName: Application
     externalId: Applications
-    description: Entity representing a Sailpoint Identity IQ Application.
+    description: Entity representing a Sailpoint ISC Application.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -298,7 +298,7 @@ entities:
     parent: Applications
     displayName: ApplicationSchemas
     externalId: applicationSchemas
-    description: Entity representing the schema associated with a Sailpoint Identity IQ Application.
+    description: Entity representing the schema associated with a Sailpoint ISC Application.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -318,7 +318,7 @@ entities:
     parent: Applications
     displayName: ApplicationLocalizedDescriptions
     externalId: descriptions
-    description: Entity representing the localized descriptions associated with a Sailpoint Identity IQ Application.
+    description: Entity representing the localized descriptions associated with a Sailpoint ISC Application.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -334,7 +334,7 @@ entities:
   Entitlement:
     displayName: Entitlement
     externalId: Entitlements
-    description: Entity representing a Sailpoint Identity IQ Entitlement.
+    description: Entity representing a Sailpoint ISC Entitlement.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -434,7 +434,7 @@ entities:
     parent: Entitlements
     displayName: EntitlementLocalizedDescriptions
     externalId: descriptions
-    description: Entity representing the localized descriptions associated with a Sailpoint Identity IQ Entitlement.
+    description: Entity representing the localized descriptions associated with a Sailpoint ISC Entitlement.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -451,7 +451,7 @@ entities:
     parent: Entitlements
     displayName: EntitlementApplications
     externalId: application
-    description: Entity representing the application associated with a Sailpoint Identity IQ Entitlement.
+    description: Entity representing the application associated with a Sailpoint ISC Entitlement.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -471,7 +471,7 @@ entities:
     parent: Entitlements
     displayName: EntitlementOwner
     externalId: owner
-    description: Entity representing the owner associated with a Sailpoint Identity IQ Entitlement.
+    description: Entity representing the owner associated with a Sailpoint ISC Entitlement.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -490,7 +490,7 @@ entities:
   LaunchedWorkflow:
     displayName: LaunchedWorkflow
     externalId: LaunchedWorkflows
-    description: Entity representing a Sailpoint Identity IQ Launched Workflow.
+    description: Entity representing a Sailpoint ISC Launched Workflow.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -579,7 +579,7 @@ entities:
     parent: LaunchedWorkflows
     displayName: LaunchedWorkflowInput
     externalId: input
-    description: Entity representing the inputs associated with a Sailpoint Identity IQ Launched Workflow.
+    description: Entity representing the inputs associated with a Sailpoint ISC Launched Workflow.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -599,7 +599,7 @@ entities:
     parent: LaunchedWorkflows
     displayName: LaunchedWorkflowOutput
     externalId: output
-    description: Entity representing the outputs associated with a Sailpoint Identity IQ Launched Workflow.
+    description: Entity representing the outputs associated with a Sailpoint ISC Launched Workflow.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -619,7 +619,7 @@ entities:
     parent: LaunchedWorkflows
     displayName: LaunchedWorkflowAttributes
     externalId: attributes
-    description: Entity representing the attributes associated with a Sailpoint Identity IQ Launched Workflow.
+    description: Entity representing the attributes associated with a Sailpoint ISC Launched Workflow.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -635,7 +635,7 @@ entities:
   ObjectConfig:
     displayName: ObjectConfig
     externalId: ObjectConfigs
-    description: Entity representing a Sailpoint Identity IQ ObjectConfig.
+    description: Entity representing a Sailpoint ISC ObjectConfig.
     syncFrequency: HOURLY
     syncMinInterval: 1
     apiCallFrequency: SECONDLY
@@ -673,7 +673,7 @@ entities:
     parent: ObjectConfigs
     displayName: ObjectConfigAttributes
     externalId: objectAttributes
-    description: Entity representing the attributes associated with a Sailpoint Identity IQ ObjectConfig.
+    description: Entity representing the attributes associated with a Sailpoint ISC ObjectConfig.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -720,7 +720,7 @@ entities:
     parent: objectAttributes
     displayName: ObjectAttributeSources
     externalId: attributeSources
-    description: Entity representing the attribute sources associated with a Sailpoint Identity IQ ObjectConfig.
+    description: Entity representing the attribute sources associated with a Sailpoint ISC ObjectConfig.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -743,7 +743,7 @@ entities:
     parent: objectAttributes
     displayName: ObjectAttributeTargets
     externalId: attributeTargets
-    description: Entity representing the attribute targets associated with a Sailpoint Identity IQ ObjectConfig.
+    description: Entity representing the attribute targets associated with a Sailpoint ISC ObjectConfig.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -768,7 +768,7 @@ entities:
   PolicyViolation:
     displayName: PolicyViolation
     externalId: PolicyViolations
-    description: Entity representing a Sailpoint Identity IQ Policy Violation.
+    description: Entity representing a Sailpoint ISC Policy Violation.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -828,7 +828,7 @@ entities:
   Role:
     displayName: Role
     externalId: Roles
-    description: Entity representing a Sailpoint Identity IQ Role.
+    description: Entity representing a Sailpoint ISC Role.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -907,7 +907,7 @@ entities:
     parent: Roles
     displayName: EntitlementLocalizedDescriptions
     externalId: descriptions
-    description: Entity representing the localized descriptions associated with a Sailpoint Identity IQ Role.
+    description: Entity representing the localized descriptions associated with a Sailpoint ISC Role.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -924,7 +924,7 @@ entities:
     parent: Roles
     displayName: RoleInheritance
     externalId: inheritance
-    description: Entity representing the inheritance associated with a Sailpoint Identity IQ Role.
+    description: Entity representing the inheritance associated with a Sailpoint ISC Role.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -944,7 +944,7 @@ entities:
     parent: Roles
     displayName: RoleRequirements
     externalId: requirements
-    description: Entity representing the requirements associated with a Sailpoint Identity IQ Role.
+    description: Entity representing the requirements associated with a Sailpoint ISC Role.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -964,7 +964,7 @@ entities:
     parent: Roles
     displayName: RolePermits
     externalId: permits
-    description: Entity representing the permits associated with a Sailpoint Identity IQ Role.
+    description: Entity representing the permits associated with a Sailpoint ISC Role.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -984,7 +984,7 @@ entities:
     parent: Roles
     displayName: RoleClassfications
     externalId: classifications
-    description: Entity representing the classifications associated with a Sailpoint Identity IQ Role.
+    description: Entity representing the classifications associated with a Sailpoint ISC Role.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1012,7 +1012,7 @@ entities:
   TaskResult:
     displayName: TaskResult
     externalId: TaskResults
-    description: Entity representing a Sailpoint Identity IQ Task Results.
+    description: Entity representing a Sailpoint ISC Task Results.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1101,7 +1101,7 @@ entities:
     parent: TaskResults
     displayName: TaskResultAttributes
     externalId: attributes
-    description: Entity representing the attributes associated with a Sailpoint Identity IQ Task Results.
+    description: Entity representing the attributes associated with a Sailpoint ISC Task Results.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1117,7 +1117,7 @@ entities:
   User:
     displayName: User
     externalId: Users
-    description: Entity representing a Sailpoint Identity IQ User.
+    description: Entity representing a Sailpoint ISC User.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1248,7 +1248,7 @@ entities:
     parent: Users
     displayName: UserEmail
     externalId: emails
-    description: Entity representing the email addresses associated with a Sailpoint Identity IQ User.
+    description: Entity representing the email addresses associated with a Sailpoint ISC User.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1271,7 +1271,7 @@ entities:
     parent: Users
     displayName: UserAccount
     externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].accounts
-    description: Entity representing the account associated with a Sailpoint Identity IQ User.
+    description: Entity representing the account associated with a Sailpoint ISC User.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1291,7 +1291,7 @@ entities:
     parent: Users
     displayName: UserEntitlements
     externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].entitlements
-    description: Entity representing the entitlements associated with a Sailpoint Identity IQ User.
+    description: Entity representing the entitlements associated with a Sailpoint ISC User.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1320,7 +1320,7 @@ entities:
     parent: Users
     displayName: UserRoles
     externalId: $..["urn:ietf:params:scim:schemas:sailpoint:1.0:User"].roles
-    description: Entity representing the roles associated with a Sailpoint Identity IQ User.
+    description: Entity representing the roles associated with a Sailpoint ISC User.
     pageSize: 100
     pagesOrderedById: false
     attributes:
@@ -1351,7 +1351,7 @@ entities:
   Workflow:
     displayName: Workflow
     externalId: Workflows
-    description: Entity representing a Sailpoint Identity IQ Workflow.
+    description: Entity representing a Sailpoint ISC Workflow.
     pageSize: 100
     pagesOrderedById: false
     attributes:


### PR DESCRIPTION
Updated to reflect the current name of the SAIL product "Identity Security Cloud" or "ISC" and not the older one "IdentityIQ" or "IIQ"