### PR TITLE
[sc-51734] Add parent relationship for JIRA template

### DIFF
--- a/jira.sgnl.yaml
+++ b/jira.sgnl.yaml
@@ -530,3 +530,8 @@ relationships:
     displayName: Issue Reporter
     fromAttribute: Issue.fields__reporter__accountId
     toAttribute: User.accountId
+  # Parent relationships
+  # FixVersions-[parent]->Issue
+  ParentOfFixVersions:
+    displayName: ParentOfFixVersions
+    childEntity: $.fields.fixVersions


### PR DESCRIPTION
[sc-51734](https://app.shortcut.com/sgnl/story/51734/production-jira-sor-template-lacks-parent-child-relationships-explicitly-declared)

Added parent relationship between FixVersions and Issue.

<img width="1187" alt="Screenshot 2025-06-20 at 11 22 26 AM" src="https://github.com/user-attachments/assets/9d2a7811-71b7-46d9-b3d3-9527e6a32686" />


