### PR TITLE
Fixing attribute alias used in Relationships

### DIFF
--- a/crowdstrike.sgnl.yaml
+++ b/crowdstrike.sgnl.yaml
@@ -706,12 +706,12 @@ relationships:
   CompromisedUserEntity:
     displayName: CompromisedUserEntity
     name: CompromisedUserEntity
-    fromAttribute: compromisedEntity.compromisedEntityId
+    fromAttribute: compromisedEntityId
     toAttribute: user.entityId
   CompromisedEndpointEntity:
     displayName: CompromisedEndpointEntity
     name: CompromisedEndpointEntity
-    fromAttribute: compromisedEntity.compromisedEntityId
+    fromAttribute: compromisedEntityId
     toAttribute: endpoint.entityId
   # Parent relationships
   ParentOfUserRiskFactor:


### PR DESCRIPTION
- the  CompromisedUserEntity and CompromisedEndpointEntity relationships "fromAttribute" only needed the attributeAlias, not the entity.attribute.alias