### PR TITLE
Remove extra incorrect EntraID relationship

### DIFF
--- a/entra-id.sgnl.yaml
+++ b/entra-id.sgnl.yaml
@@ -752,11 +752,6 @@ relationships:
     displayName: User Member
     fromAttribute: GroupMember.memberId
     toAttribute: User.id
-  GroupMember:
-    name: Member
-    displayName: Group Member
-    fromAttribute: GroupMember.memberId
-    toAttribute: Group.id
   MemberOf:
     name: MemberOf
     displayName: Member Of


### PR DESCRIPTION
<img width="944" height="152" alt="2025-09-17-165249_944x152_scrot" src="https://github.com/user-attachments/assets/85f4e7cf-09c9-4b7a-b2f6-ebc2f2aa0e79" />
<img width="929" height="76" alt="2025-09-17-165253_929x76_scrot" src="https://github.com/user-attachments/assets/421b3ae4-864d-474b-b345-b6858fd0bd83" />

The "Group Member" relationship seems to erroneously create an Entity relationship between GroupMember and Group entities where the GroupMember.memberId (which should refer to a User ID) is being matched to a Group.id.

The two intended Entity relationships for this GroupMember join table are still present in the "User Member" and "Member Of" relationships. It seems to me that this wasn't so much a typo on an otherwise needed entry, but an accidentally duplicated entry.