### PR TITLE
Updated GroupMember attributes to use distinguishedName instead of objectGUID

### DIFF
--- a/activedirectory.sgnl.yaml
+++ b/activedirectory.sgnl.yaml
@@ -99,6 +99,7 @@ entities:
         externalId: distinguishedName
         type: String
         attributeAlias: userDistinguishedName
+        indexed: true
       - name: instanceType
         externalId: instanceType
         type: Int64
@@ -337,6 +338,7 @@ entities:
         externalId: distinguishedName
         type: String
         attributeAlias: groupDistinguishedName
+        indexed: true
       - name: instanceType
         externalId: instanceType
         type: Int64

--- a/activedirectory.sgnl.yaml
+++ b/activedirectory.sgnl.yaml
@@ -98,6 +98,7 @@ entities:
       - name: distinguishedName
         externalId: distinguishedName
         type: String
+        attributeAlias: userDistinguishedName
       - name: instanceType
         externalId: instanceType
         type: Int64
@@ -335,6 +336,7 @@ entities:
       - name: distinguishedName
         externalId: distinguishedName
         type: String
+        attributeAlias: groupDistinguishedName
       - name: instanceType
         externalId: instanceType
         type: Int64
@@ -383,12 +385,12 @@ entities:
         type: String
         indexed: true
         uniqueId: true
-      - name: group_objectGUID
-        externalId: group_objectGUID
+      - name: group_distinguishedName
+        externalId: group_distinguishedName
         type: String
         indexed: true
-      - name: member_objectGUID
-        externalId: member_objectGUID
+      - name: member_distinguishedName
+        externalId: member_distinguishedName
         type: String
         indexed: true
 
@@ -396,18 +398,18 @@ relationships:
   UserMember:
     name: Member
     displayName: User Member
-    fromAttribute: GroupMember.member_objectGUID
-    toAttribute: userGUID
+    fromAttribute: GroupMember.member_distinguishedName
+    toAttribute: userDistinguishedName
   GroupMember:
     name: Member
     displayName: Group Member
-    fromAttribute: GroupMember.member_objectGUID
-    toAttribute: groupGUID
+    fromAttribute: GroupMember.member_distinguishedName
+    toAttribute: groupDistinguishedName
   MemberOf:
     name: MemberOf
     displayName: Member Of
-    fromAttribute: GroupMember.group_objectGUID
-    toAttribute: groupGUID
+    fromAttribute: GroupMember.group_distinguishedName
+    toAttribute: groupDistinguishedName
   UserMemberGroup:
     name: Group
     displayName: User Member Group


### PR DESCRIPTION
GroupMembers are created by iterating the members of each group, and only the `distinguishedName` property is available for member names as part of the range query. As a result, GroupMember relationships should be formed using `distinguishedName` for both users and groups instead of `objectGUID`.