### PR TITLE
Removing CrowdStrike Endpoint Incident

### DIFF
--- a/crowdstrike.sgnl.yaml
+++ b/crowdstrike.sgnl.yaml
@@ -623,49 +623,6 @@ entities:
         externalId: modified_timestamp
         type: DateTime
 
-  EndpointIncident:
-    displayName: Endpoint Incident
-    externalId: endpoint_protection_incident
-    description: Endpoint Incident represents an incident in the CrowdStrike platform. This is fetched from the Endpoint Protection module.
-    pageSize: 100
-    attributes:
-      - name: incidentId
-        externalId: incident_id
-        type: String
-        indexed: true
-        uniqueId: true
-      - name: state
-        externalId: state
-        type: String
-      - name: incidentType
-        externalId: incident_type
-        type: Int64
-      - name: cId
-        externalId: cid
-        type: String
-      - name: hostIds
-        externalId: host_ids
-        type: String
-        list: true
-      - name: created
-        externalId: created
-        type: DateTime
-      - name: start
-        externalId: start
-        type: DateTime
-      - name: end
-        externalId: end
-        type: DateTime
-      - name: emailState
-        externalId: email_state
-        type: String
-      - name: status
-        externalId: status
-        type: Int64
-      - name: fineScore
-        externalId: fine_score
-        type: Int64
-
   Alert:
     displayName: Alert
     externalId: endpoint_protection_alert


### PR DESCRIPTION
## Remove CrowdStrike Endpoint Incident entity

### Summary

- Removes the `EndpointIncident` entity from the CrowdStrike managed SoR template
- No relationships reference this entity, so no other changes are required

### Details

The `EndpointIncident` entity (`endpoint_protection_incident`) has been removed from `crowdstrike.sgnl.yaml`. This entity fetched incident data from the CrowdStrike Endpoint Protection module. It had no relationship dependencies in the catalog, making this a clean removal.

### Impact

- **Entities removed:** `EndpointIncident` (11 attributes)
- **Relationships impacted:** None
- **Breaking change:** Existing clients ingesting this entity will no longer receive Endpoint Incident data after upgrading to this catalog version
